### PR TITLE
Implement notification abstractions + WeeklySummaryNotifier

### DIFF
--- a/backend/services/notifications/__init__.py
+++ b/backend/services/notifications/__init__.py
@@ -1,0 +1,22 @@
+from services.notifications.interfaces import NotificationChannel, Notifier
+from services.notifications.types import (
+    ChannelResult,
+    NotifyReason,
+    NotifyResult,
+    NotifyStatus,
+    NotifyTrigger,
+    WeeklySummaryNotificationPayload,
+)
+from services.notifications.weekly_summary_notifier import WeeklySummaryNotifier
+
+__all__ = [
+    "ChannelResult",
+    "NotificationChannel",
+    "Notifier",
+    "NotifyReason",
+    "NotifyResult",
+    "NotifyStatus",
+    "NotifyTrigger",
+    "WeeklySummaryNotificationPayload",
+    "WeeklySummaryNotifier",
+]

--- a/backend/services/notifications/interfaces.py
+++ b/backend/services/notifications/interfaces.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Protocol
+
+from bson import ObjectId
+
+from services.notifications.types import ChannelResult, NotifyResult, NotifyTrigger, WeeklySummaryNotificationPayload
+
+
+class NotificationChannel(Protocol):
+    channel: str
+
+    def send(self, payload: WeeklySummaryNotificationPayload) -> ChannelResult:
+        ...
+
+
+class Notifier(Protocol):
+    def notifyWeeklySummary(
+        self,
+        *,
+        userId: ObjectId,
+        weekStart: date,
+        weekEnd: date,
+        triggeredBy: NotifyTrigger,
+    ) -> NotifyResult:
+        ...

--- a/backend/services/notifications/types.py
+++ b/backend/services/notifications/types.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+ChannelStatus = Literal["sent", "failed"]
+NotifyStatus = Literal["sent", "skipped", "failed"]
+NotifyReason = Literal["opted_out", "empty_summary", "user_not_found", "all_channels_failed"]
+NotifyTrigger = Literal["cron", "admin"]
+
+
+class WeeklySummaryUser(TypedDict):
+    id: str
+    email: str
+    fullname: str
+
+
+class WeeklySummaryData(TypedDict):
+    weekStart: str
+    weekEnd: str
+    totalLetters: int
+    totalPackages: int
+    mailboxes: list[dict[str, Any]]
+
+
+class WeeklySummaryNotificationPayload(TypedDict):
+    user: WeeklySummaryUser
+    triggeredBy: NotifyTrigger
+    summary: WeeklySummaryData
+
+
+class ChannelResult(TypedDict, total=False):
+    channel: str
+    status: ChannelStatus
+    error: str
+
+
+class NotifyResult(TypedDict, total=False):
+    status: NotifyStatus
+    channelResults: list[ChannelResult]
+    reason: NotifyReason

--- a/backend/services/notifications/weekly_summary_notifier.py
+++ b/backend/services/notifications/weekly_summary_notifier.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from bson import ObjectId
+
+from config import users_collection
+from services.mail_summary_service import MailSummaryService
+from services.notifications.interfaces import NotificationChannel
+from services.notifications.types import ChannelResult, NotifyResult, NotifyTrigger, WeeklySummaryNotificationPayload
+
+
+def _email_opted_in(user: dict[str, Any]) -> bool:
+    prefs = user.get("notifPrefs")
+    if not isinstance(prefs, list):
+        return False
+    return "email" in prefs
+
+
+class WeeklySummaryNotifier:
+    def __init__(
+        self,
+        *,
+        channels: list[NotificationChannel],
+        summaryService: MailSummaryService | None = None,
+        users=users_collection,
+    ) -> None:
+        self._channels = list(channels)
+        self._summary_service = summaryService or MailSummaryService()
+        self._users = users
+
+    def notifyWeeklySummary(
+        self,
+        *,
+        userId: ObjectId,
+        weekStart: date,
+        weekEnd: date,
+        triggeredBy: NotifyTrigger,
+    ) -> NotifyResult:
+        user = self._users.find_one({"_id": userId}, {"email": 1, "fullname": 1, "notifPrefs": 1})
+        if user is None:
+            return {"status": "failed", "reason": "user_not_found", "channelResults": []}
+
+        if not _email_opted_in(user):
+            return {"status": "skipped", "reason": "opted_out", "channelResults": []}
+
+        summary = self._summary_service.getWeeklySummary(userId=userId, weekStart=weekStart, weekEnd=weekEnd)
+        if summary["totalLetters"] + summary["totalPackages"] == 0:
+            return {"status": "skipped", "reason": "empty_summary", "channelResults": []}
+
+        payload: WeeklySummaryNotificationPayload = {
+            "user": {
+                "id": str(userId),
+                "email": str(user.get("email", "")),
+                "fullname": str(user.get("fullname", "")),
+            },
+            "triggeredBy": triggeredBy,
+            "summary": summary,
+        }
+
+        results: list[ChannelResult] = []
+        for channel in self._channels:
+            try:
+                channel_result = channel.send(payload)
+            except Exception as exc:
+                results.append({"channel": getattr(channel, "channel", "unknown"), "status": "failed", "error": str(exc)})
+                continue
+
+            normalized: ChannelResult = {
+                "channel": str(channel_result.get("channel", getattr(channel, "channel", "unknown"))),
+                "status": "sent" if channel_result.get("status") == "sent" else "failed",
+            }
+            if isinstance(channel_result.get("error"), str) and channel_result.get("error"):
+                normalized["error"] = channel_result["error"]
+            results.append(normalized)
+
+        if any(item["status"] == "sent" for item in results):
+            return {"status": "sent", "channelResults": results}
+        return {"status": "failed", "reason": "all_channels_failed", "channelResults": results}

--- a/backend/tests/test_weekly_summary_notifier.py
+++ b/backend/tests/test_weekly_summary_notifier.py
@@ -1,0 +1,174 @@
+import os
+import unittest
+from datetime import date
+
+from bson import ObjectId
+
+os.environ.setdefault("MONGO_URI", "mongodb://localhost:27017")
+
+from services.notifications.weekly_summary_notifier import WeeklySummaryNotifier
+
+
+class FakeUsersCollection:
+    def __init__(self, user_doc):
+        self._user_doc = user_doc
+        self.find_one_calls = 0
+
+    def find_one(self, _query, _projection=None):
+        self.find_one_calls += 1
+        return self._user_doc
+
+
+class FakeSummaryService:
+    def __init__(self, summary):
+        self._summary = summary
+        self.calls = 0
+
+    def getWeeklySummary(self, **_kwargs):
+        self.calls += 1
+        return self._summary
+
+
+class CapturingChannel:
+    channel = "email"
+
+    def __init__(self):
+        self.calls = 0
+        self.last_payload = None
+
+    def send(self, payload):
+        self.calls += 1
+        self.last_payload = payload
+        return {"channel": self.channel, "status": "sent"}
+
+
+class ReturningFailedChannel:
+    channel = "email"
+
+    def send(self, _payload):
+        return {"channel": self.channel, "status": "failed", "error": "provider rejected"}
+
+
+class RaisingChannel:
+    channel = "email"
+
+    def send(self, _payload):
+        raise RuntimeError("smtp offline")
+
+
+class WeeklySummaryNotifierTests(unittest.TestCase):
+    def test_notify_weekly_summary_skips_when_user_opted_out(self):
+        user_id = ObjectId()
+        notifier = WeeklySummaryNotifier(
+            channels=[CapturingChannel()],
+            users=FakeUsersCollection({"_id": user_id, "notifPrefs": []}),
+            summaryService=FakeSummaryService(self._summary(total_letters=2, total_packages=1)),
+        )
+
+        result = notifier.notifyWeeklySummary(
+            userId=user_id,
+            weekStart=date(2026, 2, 15),
+            weekEnd=date(2026, 2, 21),
+            triggeredBy="cron",
+        )
+
+        self.assertEqual(result, {"status": "skipped", "reason": "opted_out", "channelResults": []})
+
+    def test_notify_weekly_summary_fails_when_user_not_found(self):
+        user_id = ObjectId()
+        notifier = WeeklySummaryNotifier(
+            channels=[CapturingChannel()],
+            users=FakeUsersCollection(None),
+            summaryService=FakeSummaryService(self._summary(total_letters=2, total_packages=1)),
+        )
+
+        result = notifier.notifyWeeklySummary(
+            userId=user_id,
+            weekStart=date(2026, 2, 15),
+            weekEnd=date(2026, 2, 21),
+            triggeredBy="admin",
+        )
+
+        self.assertEqual(result, {"status": "failed", "reason": "user_not_found", "channelResults": []})
+
+    def test_notify_weekly_summary_skips_when_summary_is_empty(self):
+        user_id = ObjectId()
+        channel = CapturingChannel()
+        summary_service = FakeSummaryService(self._summary(total_letters=0, total_packages=0))
+        notifier = WeeklySummaryNotifier(
+            channels=[channel],
+            users=FakeUsersCollection({"_id": user_id, "notifPrefs": ["email"]}),
+            summaryService=summary_service,
+        )
+
+        result = notifier.notifyWeeklySummary(
+            userId=user_id,
+            weekStart=date(2026, 2, 15),
+            weekEnd=date(2026, 2, 21),
+            triggeredBy="cron",
+        )
+
+        self.assertEqual(result, {"status": "skipped", "reason": "empty_summary", "channelResults": []})
+        self.assertEqual(summary_service.calls, 1)
+        self.assertEqual(channel.calls, 0)
+
+    def test_notify_weekly_summary_sends_when_at_least_one_channel_succeeds(self):
+        user_id = ObjectId()
+        sent_channel = CapturingChannel()
+        failed_channel = ReturningFailedChannel()
+        notifier = WeeklySummaryNotifier(
+            channels=[failed_channel, sent_channel],
+            users=FakeUsersCollection(
+                {"_id": user_id, "email": "member@example.com", "fullname": "Member User", "notifPrefs": ["email"]}
+            ),
+            summaryService=FakeSummaryService(self._summary(total_letters=1, total_packages=2)),
+        )
+
+        result = notifier.notifyWeeklySummary(
+            userId=user_id,
+            weekStart=date(2026, 2, 15),
+            weekEnd=date(2026, 2, 21),
+            triggeredBy="admin",
+        )
+
+        self.assertEqual(result["status"], "sent")
+        self.assertEqual(len(result["channelResults"]), 2)
+        self.assertEqual(result["channelResults"][0]["status"], "failed")
+        self.assertEqual(result["channelResults"][1]["status"], "sent")
+        self.assertEqual(sent_channel.last_payload["user"]["id"], str(user_id))
+        self.assertEqual(sent_channel.last_payload["user"]["email"], "member@example.com")
+        self.assertEqual(sent_channel.last_payload["triggeredBy"], "admin")
+
+    def test_notify_weekly_summary_collects_channel_failure_without_throwing(self):
+        user_id = ObjectId()
+        notifier = WeeklySummaryNotifier(
+            channels=[RaisingChannel(), ReturningFailedChannel()],
+            users=FakeUsersCollection({"_id": user_id, "notifPrefs": ["email"]}),
+            summaryService=FakeSummaryService(self._summary(total_letters=3, total_packages=0)),
+        )
+
+        result = notifier.notifyWeeklySummary(
+            userId=user_id,
+            weekStart=date(2026, 2, 15),
+            weekEnd=date(2026, 2, 21),
+            triggeredBy="cron",
+        )
+
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["reason"], "all_channels_failed")
+        self.assertEqual(len(result["channelResults"]), 2)
+        self.assertEqual(result["channelResults"][0]["status"], "failed")
+        self.assertIn("smtp offline", result["channelResults"][0]["error"])
+
+    def _summary(self, *, total_letters: int, total_packages: int):
+        return {
+            "weekStart": "2026-02-15",
+            "weekEnd": "2026-02-21",
+            "totalLetters": total_letters,
+            "totalPackages": total_packages,
+            "mailboxes": [],
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/plans/plan-weekly-summary-notifier-notification-abstractions.md
+++ b/docs/plans/plan-weekly-summary-notifier-notification-abstractions.md
@@ -1,0 +1,102 @@
+# Open Questions
+None.
+
+# Locked Decisions
+- Opt-in source: derive notification eligibility from `"email" in user.notifPrefs`.
+- Top-level status semantics:
+  - `sent`: at least one channel succeeds.
+  - `failed`: zero channels succeed.
+  - `skipped`: no channel attempts are made.
+- Partial channel success is reported as top-level `sent`.
+- `NotifyResult` always includes `channelResults` (empty list for skipped cases).
+- `NotifyResult` includes explicit `reason` for `skipped` and `failed` outcomes.
+- Notification payload models user identity as a structured `user` object, not flattened fields.
+- Missing user handling: return `NotifyResult(status="failed", reason="user_not_found", channelResults=[])` without raising.
+
+# Task Checklist
+## Phase 1
+- ☑ Add notification intent abstractions (`Notifier`, `NotificationChannel`, `NotifyResult`, `ChannelResult`) as typed contracts.
+- ☑ Add a weekly-summary payload contract shared between notifier and channels.
+- ☑ Keep abstractions provider-agnostic and free of rendering/cron concerns.
+
+## Phase 2
+- ☑ Implement `WeeklySummaryNotifier` with user loading, opt-in guard, summary retrieval, zero-mail skip, and injected channel dispatch.
+- ☑ Ensure channel exceptions are captured into per-channel failure results without raising.
+- ☑ Return a clean structured `NotifyResult` including skip reason/status and per-channel outcomes.
+
+## Phase 3
+- ☑ Add focused unit tests covering opted-out, empty summary, successful send, and channel failure behaviors.
+- ☑ Verify tests assert no throws on channel failure and stable result shape.
+
+## Phase 1: Notification Intent Abstractions
+Affected files and changes
+- `backend/services/notifications/types.py` (new): add `TypedDict` contracts for `WeeklySummaryNotificationPayload`, `ChannelResult`, and `NotifyResult`.
+- `backend/services/notifications/interfaces.py` (new): add `Protocol` interfaces for `NotificationChannel` and `Notifier`.
+- `backend/services/notifications/__init__.py` (new): re-export core notification abstractions for concise imports.
+
+### Contracts
+- `NotificationChannel.send(payload) -> ChannelResult` where payload contains:
+  - structured target user identity object (`user: { id, email, fullname }`)
+  - computed weekly summary (`weekStart`, `weekEnd`, totals, mailbox breakdown)
+  - trigger metadata (`triggeredBy`)
+- `Notifier.notifyWeeklySummary(...) -> NotifyResult` with explicit status union (`sent|skipped|failed`), always-present `channelResults`, and `reason` for non-sent statuses.
+- Keep these modules pure typing + domain contracts (no DB access, provider SDK, rendering, or scheduling code).
+
+### Unit tests (phase-local)
+- No direct tests in this phase; type-level contracts are exercised through notifier tests in Phase 3.
+
+## Phase 2: WeeklySummaryNotifier Implementation
+Affected files and changes
+- `backend/services/notifications/weekly_summary_notifier.py` (new): implement `WeeklySummaryNotifier` with dependency-injected user collection, `MailSummaryService`, and `NotificationChannel` list.
+
+### Notifier flow
+- Input: `userId`, `weekStart`, `weekEnd`, `triggeredBy`.
+- Load user once; if missing, return `NotifyResult(status="failed", reason="user_not_found", channelResults=[])` (no throw).
+- Resolve email opt-in from `"email" in user.notifPrefs`.
+- If opted out, return `NotifyResult(status="skipped", reason="opted_out", channelResults=[])` and no channel sends.
+- Call `MailSummaryService.getWeeklySummary(...)`.
+- If `totalLetters + totalPackages == 0`, return `NotifyResult(status="skipped", reason="empty_summary", channelResults=[])`.
+- Build one immutable notification payload value and pass it to each injected channel.
+- Iterate channels independently:
+  - If `send` succeeds, append returned `ChannelResult`.
+  - If `send` raises, catch exception and append `{channel: <name>, status: "failed", error: str(exc)}`.
+- Derive top-level status from collected channel results:
+  - `sent` if at least one channel result has `status == "sent"`.
+  - `failed` if no channel result succeeded.
+  - `skipped` only for pre-dispatch exits above.
+- For `failed` outcomes after attempted dispatch, set `reason="all_channels_failed"`.
+- Never import provider SDKs, render HTML, or schedule execution here.
+
+### Unit tests (phase-local)
+- Implemented in Phase 3 against the concrete notifier behavior above.
+
+## Phase 3: Unit Tests for Notifier Behavior
+Affected files and changes
+- `backend/tests/test_weekly_summary_notifier.py` (new): add notifier-focused unit tests with lightweight fakes for user store, summary service, and channels.
+
+### Unit tests
+- `test_notify_weekly_summary_skips_when_user_opted_out`
+  - Arrange user with email notifications disabled.
+  - Assert result is `skipped` with `reason="opted_out"` and `channelResults=[]`.
+  - Assert summary service and channels are not called.
+- `test_notify_weekly_summary_fails_when_user_not_found`
+  - Arrange missing user lookup.
+  - Assert result is `failed` with `reason="user_not_found"` and `channelResults=[]`.
+  - Assert summary service and channels are not called.
+- `test_notify_weekly_summary_skips_when_summary_is_empty`
+  - Arrange opted-in user and summary with zero letters/packages.
+  - Assert result is `skipped` with `reason="empty_summary"` and `channelResults=[]`.
+  - Assert channels are not called.
+- `test_notify_weekly_summary_sends_to_channels_when_summary_has_mail`
+  - Arrange opted-in user and non-empty summary.
+  - Arrange one successful fake channel and optionally one failing channel.
+  - Assert top-level `sent` (partial success rule) and expected `channelResults` content/order.
+- `test_notify_weekly_summary_collects_channel_failure_without_throwing`
+  - Arrange all channels failing (raised exception and/or returned failed status).
+  - Assert method returns normally.
+  - Assert failed channel results include error text where applicable.
+  - Assert top-level result is `failed` with `reason="all_channels_failed"`.
+
+### Test design constraints
+- Keep tests unit-only with in-memory fakes; avoid integration tests and complex mocking.
+- Reuse deterministic week dates and ObjectIds to match existing backend test style.


### PR DESCRIPTION
Depends on #39.

* Adds `Notifier` abstraction
* Adds `NotificationChannel` abstraction
* Implements `WeeklySummaryNotifier` orchestration
* No channel delivery yet

This PR establishes the notification intent layer.

Closes #16.