### PR TITLE
Implement EmailChannel with dummy provider

### DIFF
--- a/backend/services/notifications/__init__.py
+++ b/backend/services/notifications/__init__.py
@@ -1,4 +1,7 @@
+from services.notifications.channels.email_channel import EmailChannel
 from services.notifications.interfaces import NotificationChannel, Notifier
+from services.notifications.providers.console_provider import ConsoleEmailProvider
+from services.notifications.providers.email_provider import EmailProvider
 from services.notifications.types import (
     ChannelResult,
     NotifyReason,
@@ -11,6 +14,9 @@ from services.notifications.weekly_summary_notifier import WeeklySummaryNotifier
 
 __all__ = [
     "ChannelResult",
+    "ConsoleEmailProvider",
+    "EmailChannel",
+    "EmailProvider",
     "NotificationChannel",
     "Notifier",
     "NotifyReason",

--- a/backend/services/notifications/channels/__init__.py
+++ b/backend/services/notifications/channels/__init__.py
@@ -1,0 +1,3 @@
+from services.notifications.channels.email_channel import EmailChannel
+
+__all__ = ["EmailChannel"]

--- a/backend/services/notifications/channels/email_channel.py
+++ b/backend/services/notifications/channels/email_channel.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Union
+
+from flask import render_template
+
+from services.notifications.providers.email_provider import EmailProvider
+from services.notifications.types import ChannelResult, WeeklySummaryData, WeeklySummaryNotificationPayload
+
+
+class EmailChannel:
+    channel = "email"
+
+    def __init__(self, provider: EmailProvider) -> None:
+        self.provider = provider
+
+    def send(self, payload: WeeklySummaryNotificationPayload) -> ChannelResult:
+        html = render_template(
+            "emails/weekly_summary.html",
+            summary=payload["summary"],
+            user=payload["user"],
+        )
+
+        subject = self._build_subject(payload["summary"])
+
+        try:
+            message_id = self.provider.send(
+                to=payload["user"]["email"],
+                subject=subject,
+                html=html,
+            )
+            return {
+                "channel": self.channel,
+                "status": "sent",
+                "messageId": message_id,
+            }
+        except Exception as exc:
+            return {
+                "channel": self.channel,
+                "status": "failed",
+                "error": str(exc),
+            }
+
+    def _build_subject(self, summary: WeeklySummaryData) -> str:
+        week_start = self._format_summary_date(summary["weekStart"])
+        week_end = self._format_summary_date(summary["weekEnd"])
+        return f"Your Avenu Mail Summary ({week_start}–{week_end})"
+
+    def _format_summary_date(self, value: Union[str, date, datetime]) -> str:
+        if isinstance(value, datetime):
+            return value.strftime("%b %d")
+        if isinstance(value, date):
+            return value.strftime("%b %d")
+        return datetime.strptime(value, "%Y-%m-%d").strftime("%b %d")

--- a/backend/services/notifications/providers/__init__.py
+++ b/backend/services/notifications/providers/__init__.py
@@ -1,0 +1,4 @@
+from services.notifications.providers.console_provider import ConsoleEmailProvider
+from services.notifications.providers.email_provider import EmailProvider
+
+__all__ = ["ConsoleEmailProvider", "EmailProvider"]

--- a/backend/services/notifications/providers/console_provider.py
+++ b/backend/services/notifications/providers/console_provider.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from services.notifications.providers.email_provider import EmailProvider
+
+
+class ConsoleEmailProvider(EmailProvider):
+    def send(self, *, to: str, subject: str, html: str) -> str:
+        print("=== EMAIL SEND ===")
+        print("To:", to)
+        print("Subject:", subject)
+        print("HTML:", html[:200], "...")
+        print("==================")
+        return "console-message-id"

--- a/backend/services/notifications/providers/email_provider.py
+++ b/backend/services/notifications/providers/email_provider.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class EmailProvider(ABC):
+    @abstractmethod
+    def send(self, *, to: str, subject: str, html: str) -> str:
+        raise NotImplementedError

--- a/backend/services/notifications/types.py
+++ b/backend/services/notifications/types.py
@@ -31,6 +31,7 @@ class WeeklySummaryNotificationPayload(TypedDict):
 class ChannelResult(TypedDict, total=False):
     channel: str
     status: ChannelStatus
+    messageId: str
     error: str
 
 

--- a/backend/services/notifications/weekly_summary_notifier.py
+++ b/backend/services/notifications/weekly_summary_notifier.py
@@ -71,6 +71,8 @@ class WeeklySummaryNotifier:
                 "channel": str(channel_result.get("channel", getattr(channel, "channel", "unknown"))),
                 "status": "sent" if channel_result.get("status") == "sent" else "failed",
             }
+            if isinstance(channel_result.get("messageId"), str) and channel_result.get("messageId"):
+                normalized["messageId"] = channel_result["messageId"]
             if isinstance(channel_result.get("error"), str) and channel_result.get("error"):
                 normalized["error"] = channel_result["error"]
             results.append(normalized)

--- a/backend/templates/emails/weekly_summary.html
+++ b/backend/templates/emails/weekly_summary.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Weekly Mail Summary</title>
+  </head>
+  <body>
+    <h1>Weekly Mail Summary</h1>
+    <p>Hello {{ user.fullname or user.email }},</p>
+    <p>Here is your summary for {{ summary.weekStart }} to {{ summary.weekEnd }}.</p>
+    <ul>
+      <li>Total letters: {{ summary.totalLetters }}</li>
+      <li>Total packages: {{ summary.totalPackages }}</li>
+    </ul>
+  </body>
+</html>

--- a/backend/tests/test_email_channel.py
+++ b/backend/tests/test_email_channel.py
@@ -1,0 +1,150 @@
+import io
+import os
+import unittest
+from contextlib import redirect_stdout
+from datetime import date
+
+from bson import ObjectId
+
+os.environ.setdefault("MONGO_URI", "mongodb://localhost:27017")
+
+from app import create_app
+from services.notifications.channels.email_channel import EmailChannel
+from services.notifications.providers.console_provider import ConsoleEmailProvider
+from services.notifications.providers.email_provider import EmailProvider
+from services.notifications.weekly_summary_notifier import WeeklySummaryNotifier
+
+
+class FakeEmailProvider(EmailProvider):
+    def __init__(self):
+        self.calls = []
+
+    def send(self, *, to: str, subject: str, html: str) -> str:
+        self.calls.append({"to": to, "subject": subject, "html": html})
+        return "fake-message-id"
+
+
+class RaisingEmailProvider(EmailProvider):
+    def send(self, *, to: str, subject: str, html: str) -> str:
+        raise RuntimeError("provider down")
+
+
+class FakeUsersCollection:
+    def __init__(self, user_doc):
+        self._user_doc = user_doc
+
+    def find_one(self, _query, _projection=None):
+        return self._user_doc
+
+
+class FakeSummaryService:
+    def __init__(self, summary):
+        self._summary = summary
+
+    def getWeeklySummary(self, **_kwargs):
+        return self._summary
+
+
+class EmailChannelTests(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(testing=True, ensure_db_indexes_on_startup=False)
+
+    def test_send_renders_template_and_uses_provider(self):
+        provider = FakeEmailProvider()
+        channel = EmailChannel(provider)
+
+        with self.app.app_context():
+            result = channel.send(self._payload())
+
+        self.assertEqual(result, {"channel": "email", "status": "sent", "messageId": "fake-message-id"})
+        self.assertEqual(len(provider.calls), 1)
+        self.assertEqual(provider.calls[0]["to"], "member@example.com")
+        self.assertEqual(provider.calls[0]["subject"], "Your Avenu Mail Summary (Feb 15–Feb 21)")
+        self.assertIn("Weekly Mail Summary", provider.calls[0]["html"])
+
+    def test_send_returns_failed_when_provider_raises(self):
+        channel = EmailChannel(RaisingEmailProvider())
+
+        with self.app.app_context():
+            result = channel.send(self._payload())
+
+        self.assertEqual(result["channel"], "email")
+        self.assertEqual(result["status"], "failed")
+        self.assertIn("provider down", result["error"])
+
+    def test_send_builds_subject_from_date_objects(self):
+        provider = FakeEmailProvider()
+        channel = EmailChannel(provider)
+        payload = self._payload()
+        payload["summary"]["weekStart"] = date(2026, 2, 15)
+        payload["summary"]["weekEnd"] = date(2026, 2, 21)
+
+        with self.app.app_context():
+            channel.send(payload)
+
+        self.assertEqual(provider.calls[0]["subject"], "Your Avenu Mail Summary (Feb 15–Feb 21)")
+
+    def test_console_provider_prints_and_returns_message_id(self):
+        provider = ConsoleEmailProvider()
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            message_id = provider.send(to="member@example.com", subject="Subject", html="<p>Hello</p>")
+            output = buf.getvalue()
+
+        self.assertEqual(message_id, "console-message-id")
+        self.assertIn("=== EMAIL SEND ===", output)
+        self.assertIn("To: member@example.com", output)
+        self.assertIn("Subject: Subject", output)
+
+    def test_weekly_summary_notifier_dispatches_to_email_channel(self):
+        user_id = ObjectId()
+        provider = FakeEmailProvider()
+        channel = EmailChannel(provider)
+        notifier = WeeklySummaryNotifier(
+            channels=[channel],
+            users=FakeUsersCollection(
+                {
+                    "_id": user_id,
+                    "email": "member@example.com",
+                    "fullname": "Member User",
+                    "notifPrefs": ["email"],
+                }
+            ),
+            summaryService=FakeSummaryService(self._summary(total_letters=2, total_packages=1)),
+        )
+
+        with self.app.app_context():
+            result = notifier.notifyWeeklySummary(
+                userId=user_id,
+                weekStart=date(2026, 2, 15),
+                weekEnd=date(2026, 2, 21),
+                triggeredBy="cron",
+            )
+
+        self.assertEqual(result["status"], "sent")
+        self.assertEqual(result["channelResults"], [{"channel": "email", "status": "sent", "messageId": "fake-message-id"}])
+        self.assertEqual(len(provider.calls), 1)
+
+    def _payload(self):
+        return {
+            "user": {
+                "id": str(ObjectId()),
+                "email": "member@example.com",
+                "fullname": "Member User",
+            },
+            "triggeredBy": "cron",
+            "summary": self._summary(total_letters=1, total_packages=2),
+        }
+
+    def _summary(self, *, total_letters: int, total_packages: int):
+        return {
+            "weekStart": "2026-02-15",
+            "weekEnd": "2026-02-21",
+            "totalLetters": total_letters,
+            "totalPackages": total_packages,
+            "mailboxes": [],
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Introduces `EmailProvider` interface
* Adds ConsoleEmailProvider
* Wires EmailChannel to WeeklySummaryNotifier
* Enables end-to-end local notification flow

Still no persistence or automation.

Depends on #41.