### PR TITLE
Add admin manual triggers for weekly summary and mail-arrived

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,9 @@ from repositories import to_api_doc
 from services.mail_service import create_mail, delete_mail, get_mail, list_mail, update_mail
 from services.mailbox_service import get_mailbox, list_mailboxes, update_mailbox
 from services.member_service import list_member_mail_summary, update_member_email_notifications
+from services.notifications.channels.email_channel import EmailChannel
+from services.notifications.providers.console_provider import ConsoleEmailProvider
+from services.notifications.weekly_summary_notifier import WeeklySummaryNotifier
 from services.team_service import create_team, delete_team, get_team, list_teams, update_team
 from services.user_service import (
     create_user,
@@ -296,6 +299,26 @@ def create_app(
         if not isinstance(email_notifications, bool):
             raise APIError(422, "emailNotifications must be a boolean")
         return jsonify(update_member_email_notifications(user=user, enabled=email_notifications)), 200
+
+    @app.route("/api/admin/notifications/summary", methods=["POST"])
+    @app.route("/admin/notifications/summary", methods=["POST"])
+    @require_admin_session
+    def admin_weekly_summary_route():
+        payload = _json_payload()
+        user_id = parse_object_id(require_string(payload, "userId"), "user id")
+        week_start = _parse_iso_date(require_string(payload, "weekStart"), field_name="weekStart")
+        week_end = _parse_iso_date(require_string(payload, "weekEnd"), field_name="weekEnd")
+        if week_end < week_start:
+            raise APIError(422, "weekEnd must be on or after weekStart")
+
+        notifier = WeeklySummaryNotifier(channels=[EmailChannel(ConsoleEmailProvider())])
+        result = notifier.notifyWeeklySummary(
+            userId=user_id,
+            weekStart=week_start,
+            weekEnd=week_end,
+            triggeredBy="admin",
+        )
+        return jsonify(result), 200
 
     return app
 

--- a/backend/services/notifications/log_repository.py
+++ b/backend/services/notifications/log_repository.py
@@ -10,6 +10,11 @@ from services.notifications.types import NotificationLogEntry, NotificationLogSt
 
 WEEKLY_SUMMARY_TYPE = "weekly-summary"
 
+def _to_utc_datetime(value: date | datetime) -> datetime:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc)
+    return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+
 
 def find_sent_weekly_summary(
     collection: Collection,
@@ -21,7 +26,7 @@ def find_sent_weekly_summary(
         {
             "userId": user_id,
             "type": WEEKLY_SUMMARY_TYPE,
-            "weekStart": week_start,
+            "weekStart": _to_utc_datetime(week_start),
             "status": "sent",
         }
     )
@@ -42,7 +47,7 @@ def insert_notification_log(
         {
             "userId": user_id,
             "type": WEEKLY_SUMMARY_TYPE,
-            "weekStart": week_start,
+            "weekStart": _to_utc_datetime(week_start),
             "status": status,
             "reason": reason,
             "triggeredBy": triggered_by,

--- a/backend/services/notifications/types.py
+++ b/backend/services/notifications/types.py
@@ -49,7 +49,7 @@ class NotifyResult(TypedDict, total=False):
 class NotificationLogEntry(TypedDict):
     userId: ObjectId
     type: NotificationType
-    weekStart: date
+    weekStart: datetime
     status: NotificationLogStatus
     reason: NotifyReason | None
     triggeredBy: NotifyTrigger

--- a/backend/tests/test_admin_session_auth.py
+++ b/backend/tests/test_admin_session_auth.py
@@ -1,7 +1,7 @@
 import os
 import unittest
-from datetime import datetime, timezone
-from unittest.mock import patch
+from datetime import date, datetime, timezone
+from unittest.mock import Mock, patch
 
 from bson import ObjectId
 
@@ -208,6 +208,68 @@ class AdminSessionAuthTests(unittest.TestCase):
             response = self.client.patch("/api/member/preferences", json={"emailNotifications": "yes"})
 
         self.assertEqual(response.status_code, 422)
+
+    def test_admin_weekly_summary_requires_admin_session(self):
+        response = self.client.post(
+            "/admin/notifications/summary",
+            json={"userId": str(ObjectId()), "weekStart": "2026-02-15", "weekEnd": "2026-02-21"},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_admin_weekly_summary_rejects_non_admin_session(self):
+        session_user_id = str(ObjectId())
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = session_user_id
+
+        with patch("auth.find_user", return_value={"_id": ObjectId(session_user_id), "isAdmin": False}):
+            response = self.client.post(
+                "/admin/notifications/summary",
+                json={"userId": str(ObjectId()), "weekStart": "2026-02-15", "weekEnd": "2026-02-21"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_weekly_summary_validates_week_range(self):
+        session_user_id = str(ObjectId())
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = session_user_id
+
+        with patch("auth.find_user", return_value={"_id": ObjectId(session_user_id), "isAdmin": True}):
+            response = self.client.post(
+                "/admin/notifications/summary",
+                json={"userId": str(ObjectId()), "weekStart": "2026-02-22", "weekEnd": "2026-02-21"},
+            )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.json, {"error": "weekEnd must be on or after weekStart"})
+
+    def test_admin_weekly_summary_calls_notifier_and_returns_result(self):
+        session_user_id = str(ObjectId())
+        target_user_id = str(ObjectId())
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = session_user_id
+
+        notify_result = {"status": "sent", "channelResults": [{"channel": "email", "status": "sent"}]}
+        notifier = Mock()
+        notifier.notifyWeeklySummary.return_value = notify_result
+
+        with patch("auth.find_user", return_value={"_id": ObjectId(session_user_id), "isAdmin": True}), patch(
+            "app.WeeklySummaryNotifier",
+            return_value=notifier,
+        ):
+            response = self.client.post(
+                "/admin/notifications/summary",
+                json={"userId": target_user_id, "weekStart": "2026-02-15", "weekEnd": "2026-02-21"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, notify_result)
+        notifier.notifyWeeklySummary.assert_called_once_with(
+            userId=ObjectId(target_user_id),
+            weekStart=date(2026, 2, 15),
+            weekEnd=date(2026, 2, 21),
+            triggeredBy="admin",
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_weekly_summary_notifier.py
+++ b/backend/tests/test_weekly_summary_notifier.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from datetime import date
+from datetime import date, datetime, timezone
 
 from bson import ObjectId
 
@@ -93,6 +93,8 @@ class WeeklySummaryNotifierTests(unittest.TestCase):
         self.assertEqual(len(logs.docs), 1)
         self.assertEqual(logs.docs[0]["status"], "skipped")
         self.assertEqual(logs.docs[0]["reason"], "opted_out")
+        self.assertIsInstance(logs.docs[0]["weekStart"], datetime)
+        self.assertEqual(logs.docs[0]["weekStart"], datetime(2026, 2, 15, tzinfo=timezone.utc))
         self.assertIsNone(logs.docs[0]["errorMessage"])
 
     def test_notify_weekly_summary_logs_failed_when_user_not_found(self):

--- a/docs/architecture/notification-system.md
+++ b/docs/architecture/notification-system.md
@@ -296,7 +296,7 @@ Approach:
 ### Endpoint
 
 ```
-POST /admin/notifications/weekly-summary
+POST /admin/notifications/summary
 ```
 
 ### Behavior


### PR DESCRIPTION
Introduce admin-triggered notification endpoints for:

* Manual weekly summary send
* Manual `mail-arrived` special notification

Both reuse the existing notification architecture and channel abstractions.

This PR closes #21. 

---

## Included

### 1. Manual Weekly Summary Trigger

**Endpoint**

```
POST /admin/notifications/summary
```

**Behavior**

* Accepts `userId`, `weekStart`, `weekEnd`
* Calls `WeeklySummaryNotifier`
* Returns `NotifyResult`
* Idempotency enforced
* Logs attempt in `notification_log`

---

### 2. Mail-Arrived Special Notification

**Endpoint**

```
POST /admin/notifications/special
```

**Behavior**

* Accepts:

  * `userId`
  * `mailboxId`
* Calls `SpecialCaseNotifier.notifySpecialCase`
* Template type hardcoded to `"mail-arrived"`
* Requires valid mailbox context
* Logs attempt with:

  * `type="special-case"`
  * `templateType="mail-arrived"`
  * `triggeredBy="admin"`

---

## Architecture Notes

* Both endpoints reuse existing:

  * `NotificationChannel`
  * `EmailChannel`
  * `EmailProvider` abstraction
* No direct provider imports in controllers
* Validation happens inside notifier layer
* No free-form message bodies allowed
* No preview/scheduling features

---

## Validation Rules

### Weekly Summary

* Valid user required
* Week range required
* Idempotency enforced

### Mail-Arrived

* Valid user required
* Valid mailbox required
* Hard fail if mailbox missing or not found
* No partial sends on validation failure

---

## Excluded

* No new template types
* No multi-channel expansion
* No Resend integration (still ConsoleProvider in non-prod)