### PR TITLE
Get full name and phone number of authenticated user from Optix

### DIFF
--- a/backend/repositories/users_repository.py
+++ b/backend/repositories/users_repository.py
@@ -149,6 +149,7 @@ def upsert_user_from_external_identity(
     optix_id: int,
     fullname: str,
     email: str,
+    phone: str,
     is_admin: bool,
     team_ids: list[ObjectId],
     notif_prefs: list[str],
@@ -160,6 +161,7 @@ def upsert_user_from_external_identity(
                 "optixId": optix_id,
                 "fullname": fullname,
                 "email": email,
+                "phone": phone,
                 "isAdmin": is_admin,
                 "teamIds": team_ids,
                 "notifPrefs": notif_prefs,
@@ -176,6 +178,7 @@ def upsert_user_from_external_identity(
         {
             "fullname": fullname,
             "email": email,
+            "phone": phone,
             "isAdmin": is_admin,
             "teamIds": team_ids,
             "notifPrefs": notif_prefs,

--- a/backend/services/identity_sync_service.py
+++ b/backend/services/identity_sync_service.py
@@ -17,6 +17,7 @@ query {
       user_id
       email
       fullname
+      phone
       is_admin
       teams {
         team_id
@@ -95,6 +96,7 @@ def sync_optix_identity(*, token: str) -> tuple[bool, dict[str, Any]]:
         optix_id=optix_user_id,
         fullname=user_info.get("fullname", ""),
         email=user_info.get("email", ""),
+        phone=user_info.get("phone", ""),
         is_admin=bool(user_info.get("is_admin", False)),
         team_ids=team_ids,
         notif_prefs=["email"],

--- a/backend/services/identity_sync_service.py
+++ b/backend/services/identity_sync_service.py
@@ -16,7 +16,7 @@ query {
     user {
       user_id
       email
-      name
+      fullname
       is_admin
       teams {
         team_id
@@ -93,7 +93,7 @@ def sync_optix_identity(*, token: str) -> tuple[bool, dict[str, Any]]:
 
     user_doc, created = upsert_user_from_external_identity(
         optix_id=optix_user_id,
-        fullname=user_info.get("name", ""),
+        fullname=user_info.get("fullname", ""),
         email=user_info.get("email", ""),
         is_admin=bool(user_info.get("is_admin", False)),
         team_ids=team_ids,


### PR DESCRIPTION
Update the GraphQL query to return the full name instead of just the first name, and also get the logged-in user's phone number.

Insert the phone number value into the corresponding doc in the DB for the user.  

Resolves #93 