### PR TITLE
Resolved HTTP 422 error code arising for some autologin attempts

### DIFF
--- a/backend/tests/unit/test_validators.py
+++ b/backend/tests/unit/test_validators.py
@@ -20,6 +20,12 @@ class ValidatorTests(unittest.TestCase):
         self.assertEqual(len(parsed), 1)
         self.assertEqual(str(parsed[0]), oid)
 
+    def test_parse_distinct_object_ids_accepts_object_id_instances(self):
+        oid = ObjectId()
+        parsed = parse_distinct_object_ids([oid, oid], "teamIds")
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0], oid)
+
     def test_parse_enum_set_rejects_invalid(self):
         with self.assertRaises(APIError):
             parse_enum_set(["email", "push"], field_name="notifPrefs", allowed={"email", "text"})

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -83,9 +83,12 @@ def parse_distinct_object_ids(values: Any, field_name: str) -> list[ObjectId]:
     unique_ids: list[ObjectId] = []
     seen: set[ObjectId] = set()
     for raw in values:
-        if not isinstance(raw, str) or not ObjectId.is_valid(raw):
-            raise APIError(422, f"{field_name} must contain ObjectId strings")
-        oid = ObjectId(raw)
+        if isinstance(raw, ObjectId):
+            oid = raw
+        elif isinstance(raw, str) and ObjectId.is_valid(raw):
+            oid = ObjectId(raw)
+        else:
+            raise APIError(422, f"{field_name} must contain valid ObjectIds")
         if oid not in seen:
             seen.add(oid)
             unique_ids.append(oid)


### PR DESCRIPTION
422 error code was arising because `parse_distinct_object_ids` function was not accepting `list[ObjectId]` beforehand and would throw the error, but the type being passed to it was `list[ObjectId]`

This function is called on teamIds when a user doc is constructed during (auto)login for the first time

Resolves #92 