### PR TITLE
Fix skipped mail request notification status

### DIFF
--- a/backend/models/builders.py
+++ b/backend/models/builders.py
@@ -22,7 +22,7 @@ NOTIF_PREFS = {"email", "text"}
 MAILBOX_TYPES = {"user", "team"}
 MAIL_TYPES = {"letter", "package"}
 MAIL_REQUEST_STATUSES = {"ACTIVE", "CANCELLED", "RESOLVED"}
-MAIL_REQUEST_NOTIFICATION_STATUSES = {"SENT", "FAILED"}
+MAIL_REQUEST_NOTIFICATION_STATUSES = {"SENT", "SKIPPED", "FAILED"}
 
 
 def _utcnow() -> datetime:

--- a/backend/services/mail_request_service.py
+++ b/backend/services/mail_request_service.py
@@ -83,8 +83,13 @@ def _log_special_case_exception(*, user_id: ObjectId, exc: Exception) -> None:
     )
 
 
-def _notification_status_from_notify_result(result: dict[str, Any]) -> Literal["SENT", "FAILED"]:
-    return "SENT" if result.get("status") == "sent" else "FAILED"
+def _notification_status_from_notify_result(result: dict[str, Any]) -> Literal["SENT", "SKIPPED", "FAILED"]:
+    status = result.get("status")
+    if status == "sent":
+        return "SENT"
+    if status == "skipped":
+        return "SKIPPED"
+    return "FAILED"
 
 
 def _build_mail_request_notification_context(request_doc: dict[str, Any]) -> dict[str, Any]:
@@ -127,7 +132,7 @@ def resolve_mail_request_and_notify(
         raise APIError(500, "mail request has invalid member id")
 
     resolved_notifier = notifier or _default_special_case_notifier()
-    notification_status: Literal["SENT", "FAILED"] = "FAILED"
+    notification_status: Literal["SENT", "SKIPPED", "FAILED"] = "FAILED"
     notification_at = _utcnow()
     try:
         notify_result = resolved_notifier.notifySpecialCase(
@@ -172,7 +177,7 @@ def retry_mail_request_notification(
         raise APIError(500, "mail request has invalid member id")
 
     resolved_notifier = notifier or _default_special_case_notifier()
-    notification_status: Literal["SENT", "FAILED"] = "FAILED"
+    notification_status: Literal["SENT", "SKIPPED", "FAILED"] = "FAILED"
     notification_at = _utcnow()
     try:
         notify_result = resolved_notifier.notifySpecialCase(

--- a/backend/tests/unit/test_admin_session_auth.py
+++ b/backend/tests/unit/test_admin_session_auth.py
@@ -752,6 +752,33 @@ class AdminSessionAuthTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_admin_resolve_mail_request_returns_skipped_notification_metadata(self):
+        session_user_id = str(ObjectId())
+        request_id = str(ObjectId())
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = session_user_id
+
+        expected = {
+            "_id": ObjectId(request_id),
+            "memberId": ObjectId(),
+            "mailboxId": ObjectId(),
+            "status": "RESOLVED",
+            "resolvedAt": datetime(2026, 2, 20, tzinfo=timezone.utc),
+            "resolvedBy": ObjectId(session_user_id),
+            "lastNotificationStatus": "SKIPPED",
+            "lastNotificationAt": datetime(2026, 2, 20, tzinfo=timezone.utc),
+            "createdAt": datetime(2026, 2, 19, tzinfo=timezone.utc),
+            "updatedAt": datetime(2026, 2, 20, tzinfo=timezone.utc),
+        }
+        with patch("controllers.auth_guard.find_user", return_value={"_id": ObjectId(session_user_id), "isAdmin": True}), patch(
+            "controllers.mail_requests_controller.resolve_mail_request_and_notify",
+            return_value=expected,
+        ):
+            response = self.client.post(f"/api/admin/mail-requests/{request_id}/resolve")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["lastNotificationStatus"], "SKIPPED")
+
     def test_admin_retry_notification_requires_admin_session(self):
         response = self.client.post(f"/api/admin/mail-requests/{ObjectId()}/retry-notification")
         self.assertEqual(response.status_code, 401)
@@ -785,6 +812,33 @@ class AdminSessionAuthTests(unittest.TestCase):
         self.assertEqual(response.json["lastNotificationStatus"], "FAILED")
         retry_mock.assert_called_once()
         self.assertEqual(retry_mock.call_args.kwargs["request_id"], ObjectId(request_id))
+
+    def test_admin_retry_notification_returns_skipped_notification_metadata(self):
+        session_user_id = str(ObjectId())
+        request_id = str(ObjectId())
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = session_user_id
+
+        expected = {
+            "_id": ObjectId(request_id),
+            "memberId": ObjectId(),
+            "mailboxId": ObjectId(),
+            "status": "RESOLVED",
+            "resolvedAt": datetime(2026, 2, 20, tzinfo=timezone.utc),
+            "resolvedBy": ObjectId(session_user_id),
+            "lastNotificationStatus": "SKIPPED",
+            "lastNotificationAt": datetime(2026, 2, 21, tzinfo=timezone.utc),
+            "createdAt": datetime(2026, 2, 19, tzinfo=timezone.utc),
+            "updatedAt": datetime(2026, 2, 21, tzinfo=timezone.utc),
+        }
+        with patch("controllers.auth_guard.find_user", return_value={"_id": ObjectId(session_user_id), "isAdmin": True}), patch(
+            "controllers.mail_requests_controller.retry_mail_request_notification",
+            return_value=expected,
+        ):
+            response = self.client.post(f"/api/admin/mail-requests/{request_id}/retry-notification")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["lastNotificationStatus"], "SKIPPED")
 
     def test_admin_weekly_summary_requires_admin_session(self):
         response = self.client.post(

--- a/backend/tests/unit/test_mail_request_service.py
+++ b/backend/tests/unit/test_mail_request_service.py
@@ -281,6 +281,42 @@ class MailRequestServiceTests(unittest.TestCase):
         self.assertEqual(updated["lastNotificationStatus"], "FAILED")
         self.assertIsNotNone(updated["lastNotificationAt"])
 
+    def test_resolve_mail_request_sets_last_notification_skipped_metadata_on_skipped_result(self):
+        member_id = ObjectId()
+        admin_id = ObjectId()
+        request_id = ObjectId()
+        collection = FakeCollection(
+            [
+                {
+                    "_id": request_id,
+                    "memberId": member_id,
+                    "status": "ACTIVE",
+                    "resolvedAt": None,
+                    "resolvedBy": None,
+                    "lastNotificationStatus": None,
+                    "lastNotificationAt": None,
+                    "updatedAt": datetime(2026, 2, 2, tzinfo=timezone.utc),
+                }
+            ]
+        )
+        notifier = Mock()
+        notifier.notifySpecialCase.return_value = {
+            "status": "skipped",
+            "reason": "opted_out",
+            "channelResults": [],
+        }
+
+        with patch("repositories.mail_requests_repository.mail_requests_collection", collection):
+            updated = mail_request_service.resolve_mail_request_and_notify(
+                request_id=request_id,
+                admin_user={"_id": admin_id},
+                notifier=notifier,
+            )
+
+        self.assertEqual(updated["status"], "RESOLVED")
+        self.assertEqual(updated["lastNotificationStatus"], "SKIPPED")
+        self.assertIsNotNone(updated["lastNotificationAt"])
+
     def test_resolve_mail_request_returns_404_when_missing_or_not_active(self):
         request_id = ObjectId()
         collection = FakeCollection(
@@ -349,6 +385,43 @@ class MailRequestServiceTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.status_code, 404)
         notifier.notifySpecialCase.assert_not_called()
+
+    def test_retry_notification_sets_last_notification_skipped_metadata_on_skipped_result(self):
+        member_id = ObjectId()
+        request_id = ObjectId()
+        resolved_at = datetime(2026, 2, 2, tzinfo=timezone.utc)
+        collection = FakeCollection(
+            [
+                {
+                    "_id": request_id,
+                    "memberId": member_id,
+                    "status": "RESOLVED",
+                    "resolvedAt": resolved_at,
+                    "resolvedBy": ObjectId(),
+                    "lastNotificationStatus": "FAILED",
+                    "lastNotificationAt": datetime(2026, 2, 2, 1, tzinfo=timezone.utc),
+                    "updatedAt": datetime(2026, 2, 2, 1, tzinfo=timezone.utc),
+                }
+            ]
+        )
+        notifier = Mock()
+        notifier.notifySpecialCase.return_value = {
+            "status": "skipped",
+            "reason": "opted_out",
+            "channelResults": [],
+        }
+
+        with patch("repositories.mail_requests_repository.mail_requests_collection", collection):
+            updated = mail_request_service.retry_mail_request_notification(
+                request_id=request_id,
+                admin_user={"_id": ObjectId()},
+                notifier=notifier,
+            )
+
+        self.assertEqual(updated["status"], "RESOLVED")
+        self.assertEqual(updated["resolvedAt"], resolved_at)
+        self.assertEqual(updated["lastNotificationStatus"], "SKIPPED")
+        self.assertIsNotNone(updated["lastNotificationAt"])
 
     def test_resolve_mail_request_exception_logs_failure_and_keeps_resolution(self):
         member_id = ObjectId()

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -97,7 +97,7 @@ class ModelBuilderTests(unittest.TestCase):
         self.assertEqual(MAIL_REQUEST_STATUSES, {"ACTIVE", "CANCELLED", "RESOLVED"})
 
     def test_mail_request_notification_status_enum(self):
-        self.assertEqual(MAIL_REQUEST_NOTIFICATION_STATUSES, {"SENT", "FAILED"})
+        self.assertEqual(MAIL_REQUEST_NOTIFICATION_STATUSES, {"SENT", "SKIPPED", "FAILED"})
 
 
 if __name__ == "__main__":

--- a/docs/01-architecture/data-model.md
+++ b/docs/01-architecture/data-model.md
@@ -85,7 +85,7 @@ Fields:
 - `status: "ACTIVE" | "CANCELLED" | "RESOLVED"`
 - `resolvedAt: datetime | null`
 - `resolvedBy: ObjectId | null` (references admin `users._id`)
-- `lastNotificationStatus: "SENT" | "FAILED" | null`
+- `lastNotificationStatus: "SENT" | "SKIPPED" | "FAILED" | null`
 - `lastNotificationAt: datetime | null`
 - `createdAt: datetime`
 - `updatedAt: datetime`
@@ -99,6 +99,7 @@ Rules:
 - `CANCELLED` and `RESOLVED` are terminal lifecycle states.
 - `resolvedAt` and `resolvedBy` must be set when `status == "RESOLVED"`.
 - `lastNotificationStatus`/`lastNotificationAt` capture send outcome metadata for resolve/retry attempts and do not affect lifecycle transitions.
+- `lastNotificationStatus == "SKIPPED"` means the notifier intentionally did not send anything and no delivery failure occurred.
 - No linkage to `mail` records; this is declaration-only.
 
 Indexes:

--- a/docs/01-architecture/diagrams/data-model.mmd
+++ b/docs/01-architecture/diagrams/data-model.mmd
@@ -43,7 +43,7 @@ erDiagram
         enum status "ACTIVE | CANCELLED | RESOLVED"
         datetime resolvedAt
         ObjectId resolvedBy FK
-        enum lastNotificationStatus "SENT | FAILED"
+        enum lastNotificationStatus "SENT | SKIPPED | FAILED"
         datetime lastNotificationAt
     }
 

--- a/docs/01-architecture/notification-system.md
+++ b/docs/01-architecture/notification-system.md
@@ -94,7 +94,7 @@ No standalone admin special notification endpoint is used for mail-arrived sends
 1. Resolve flow transitions request lifecycle to `RESOLVED` when request is currently `ACTIVE`.
 2. Backend invokes `SpecialCaseNotifier.notifySpecialCase(userId, triggeredBy="admin")`.
 3. Notification outcome is persisted on `MAIL_REQUEST`:
-   - `lastNotificationStatus = "SENT" | "FAILED"`
+   - `lastNotificationStatus = "SENT" | "SKIPPED" | "FAILED"`
    - `lastNotificationAt = datetime`
 4. Retry flow re-invokes notifier without lifecycle mutation.
 
@@ -102,6 +102,7 @@ Failure policy:
 
 - Notification failures do not roll back mail-request resolution.
 - Notifier failures are explicitly logged in `NOTIFICATION_LOG` (`type="special-case"`, `templateType="mail-arrived"`).
+- `SKIPPED` means the notifier intentionally produced no send, including opt-out and all-channel-skip outcomes.
 
 ## Public API Scope
 

--- a/docs/02-plans/plan-fix-mail-request-skipped-notification-status.md
+++ b/docs/02-plans/plan-fix-mail-request-skipped-notification-status.md
@@ -8,8 +8,8 @@
 - ☑ Add backend unit tests for skipped resolve/retry notification paths.
 
 ## Phase 2
-- ☐ Align frontend API types with the expanded mail-request notification status.
-- ☐ Update architecture/docs to define `skipped` semantics consistently across `MAIL_REQUEST` and `NOTIFICATION_LOG`.
+- ☑ Align frontend API types with the expanded mail-request notification status.
+- ☑ Update architecture/docs to define `skipped` semantics consistently across `MAIL_REQUEST` and `NOTIFICATION_LOG`.
 
 ## Phase 1: Backend Status Alignment
 Affected files and changes

--- a/docs/02-plans/plan-fix-mail-request-skipped-notification-status.md
+++ b/docs/02-plans/plan-fix-mail-request-skipped-notification-status.md
@@ -1,0 +1,58 @@
+# Open Questions
+- None.
+
+# Task Checklist
+## Phase 1
+- ☑ Add `SKIPPED` to mail-request notification status values.
+- ☑ Preserve notifier `skipped` outcomes when persisting `MAIL_REQUEST.lastNotificationStatus`.
+- ☑ Add backend unit tests for skipped resolve/retry notification paths.
+
+## Phase 2
+- ☐ Align frontend API types with the expanded mail-request notification status.
+- ☐ Update architecture/docs to define `skipped` semantics consistently across `MAIL_REQUEST` and `NOTIFICATION_LOG`.
+
+## Phase 1: Backend Status Alignment
+Affected files and changes
+- `backend/models/builders.py`
+  - Extend `MAIL_REQUEST_NOTIFICATION_STATUSES` to `{"SENT", "SKIPPED", "FAILED"}`.
+  - Keep mail-request lifecycle status handling unchanged.
+- `backend/services/mail_request_service.py`
+  - Change `_notification_status_from_notify_result` to map notifier outcomes directly:
+    - `sent -> "SENT"`
+    - `skipped -> "SKIPPED"`
+    - `failed` and unexpected values -> `"FAILED"`
+  - Reuse the same mapping for both resolve and retry flows so `MAIL_REQUEST.lastNotificationStatus` preserves notifier semantics without changing lifecycle transitions.
+- `backend/tests/unit/test_mail_request_service.py`
+  - Add resolve and retry cases where `notifySpecialCase()` returns `status="skipped"` and assert `lastNotificationStatus == "SKIPPED"`.
+  - Keep existing sent/failed/non-rollback coverage intact.
+- `backend/tests/unit/test_models.py`
+  - Update enum coverage to assert `MAIL_REQUEST_NOTIFICATION_STATUSES == {"SENT", "SKIPPED", "FAILED"}`.
+- `backend/tests/unit/test_admin_session_auth.py`
+  - Extend response-shape coverage so admin resolve/retry endpoints accept and return `lastNotificationStatus="SKIPPED"`.
+
+### Unit tests (phase-local)
+- `backend/tests/unit/test_mail_request_service.py`
+  - `test_resolve_mail_request_sets_last_notification_skipped_metadata_on_skipped_result`
+  - `test_retry_notification_sets_last_notification_skipped_metadata_on_skipped_result`
+- `backend/tests/unit/test_models.py`
+  - `test_mail_request_notification_status_enum`
+- `backend/tests/unit/test_admin_session_auth.py`
+  - `test_admin_resolve_mail_request_returns_skipped_notification_metadata`
+  - `test_admin_retry_notification_returns_skipped_notification_metadata`
+
+## Phase 2: Contract and Documentation Alignment
+Affected files and changes
+- `frontend/src/lib/api/contracts/types.ts`
+  - Expand `ApiMailRequestNotificationStatus` to `"SENT" | "SKIPPED" | "FAILED"`.
+  - Update `ApiNotifyChannelResult.status` to include `"skipped"` so notifier result typing matches backend behavior.
+- `docs/01-architecture/data-model.md`
+  - Update `MAIL_REQUEST.lastNotificationStatus` to `"SENT" | "SKIPPED" | "FAILED" | null`.
+  - Clarify that `SKIPPED` means no notification was sent and no delivery failure occurred.
+- `docs/01-architecture/notification-system.md`
+  - Define `skipped` as an intentional non-send for mail-arrived notifications, including opt-out and all-channel-skip cases.
+  - Align the resolve/retry flow description with the expanded `MAIL_REQUEST.lastNotificationStatus`.
+- `docs/01-architecture/diagrams/data-model.mmd`
+  - Update the `MAIL_REQUEST.lastNotificationStatus` enum to include `SKIPPED`.
+
+### Unit tests (phase-local)
+- No additional unit tests in this phase; contract and documentation alignment only.

--- a/frontend/src/lib/api/contracts/types.ts
+++ b/frontend/src/lib/api/contracts/types.ts
@@ -79,7 +79,7 @@ export interface ApiMemberPreferences {
 }
 
 export type ApiMailRequestStatus = "ACTIVE" | "CANCELLED" | "RESOLVED";
-export type ApiMailRequestNotificationStatus = "SENT" | "FAILED";
+export type ApiMailRequestNotificationStatus = "SENT" | "SKIPPED" | "FAILED";
 
 export interface ApiMailRequest {
   id: string;
@@ -100,7 +100,7 @@ export interface ApiMailRequest {
 
 export interface ApiNotifyChannelResult {
   channel: string;
-  status: "sent" | "failed";
+  status: "sent" | "skipped" | "failed";
   messageId?: string;
   error?: string;
 }


### PR DESCRIPTION
## Problem

Mail-request notifications use three notifier outcomes (`sent`, `skipped`, `failed`), but `MAIL_REQUEST.lastNotificationStatus` only supported `SENT` and `FAILED`. As a result, intentionally skipped notifications, such as opted-out users or all-channel skip cases, were being persisted as `FAILED`.

Impact: this does not break notification delivery, but it does make admin-visible request metadata inaccurate and can cause skipped notifications to be interpreted as actual delivery failures.

## Solution

Expand the mail-request notification status model to include `SKIPPED` and preserve notifier results end to end instead of coercing every non-`sent` outcome to `FAILED`.

The backend now maps `notifySpecialCase()` results directly into `MAIL_REQUEST.lastNotificationStatus`, adds unit coverage for skipped resolve and retry flows, and keeps the lifecycle semantics unchanged. The frontend API contract and architecture docs were updated in the same pass so persisted request metadata, response types, and documentation all use the same status model.

The alternative was to keep the two-state mail-request field and document it as a lossy send-attempt summary, but that would have preserved misleading state instead of fixing the inconsistency.

## Testing

- [x] Manual testing steps performed
- [x] Unit tests added/updated
- [x] Tested edge cases: skipped notifier result on resolve, skipped notifier result on retry, admin resolve/retry responses carrying `SKIPPED`, frontend contract build

## Risks

Low risk. The main behavior change is that consumers of `lastNotificationStatus` may now see `SKIPPED` where they previously saw an inaccurate `FAILED`. This PR updates the frontend contract and docs to keep that change explicit and aligned.

## Screenshots/Videos

No UI changes

## Related

Fixes #74

## Reviewer Notes

Please focus review on the status-mapping boundary in `mail_request_service.py` and on whether `SKIPPED` is now represented consistently anywhere `lastNotificationStatus` is surfaced.
