### PR TITLE
Add Watchtower for automatic image updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Production uses:
 
 - Docker Hub images for `frontend`, `backend`, and `scheduler`
 - a Dockge-managed `docker-compose-prod.yml` stack
+- Watchtower in the same stack: it polls the registry on a fixed interval (currently 300 seconds in `docker-compose-prod.yml`) and recreates containers when newer images are available. The application services carry `com.centurylinklabs.watchtower.enable=true` labels so only those images are watched.
 - host nginx routing public traffic to the internal container ports
 - external MongoDB
 - Prometheus and Grafana as part of the production Compose stack
@@ -291,14 +292,17 @@ docker buildx build --platform linux/amd64 -t <namespace>/avenu-scheduler:latest
 
 Replace `<namespace>` with the Docker Hub account or org that owns the images. The sample production Compose defaults to `chunkitw`, but future maintainers should treat that as an overrideable placeholder, not a permanent constant.
 
-### Dockge Update Flow
+### Image rollout and Dockge
 
-After images are published:
+After CI (or a maintainer) publishes new `frontend`, `backend`, or `scheduler` images to Docker Hub, Watchtower detects newer tags on its poll interval and replaces those containers automatically. You do not need to open Dockge and click **Update** for routine image-only rollouts.
 
-1. Open the `avenu-mail` stack in Dockge.
-2. Confirm the stack uses the expected `IMAGE_NAMESPACE` and runtime `.env`.
-3. Click `Update` so Dockge pulls the latest images and restarts the services.
-4. Hard refresh the browser after the rollout if frontend assets changed.
+Use Dockge when something outside Watchtower’s scope changes, for example:
+
+- edits to `docker-compose-prod.yml` or stack wiring
+- new or changed runtime variables in the Dockge `.env` (Compose `env_file` / environment)
+- first-time stack bring-up or recovery after manual intervention
+
+After any rollout that changes the frontend bundle, hard refresh the browser so clients load new assets.
 
 ### Rollback
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -2,6 +2,8 @@ version: "3.8"
 services:
   frontend:
     image: ${IMAGE_NAMESPACE:-chunkitw}/avenu-frontend:latest
+    labels:
+    - "com.centurylinklabs.watchtower.enable=true"
     ports:
       - 18080:80
     depends_on:
@@ -11,6 +13,8 @@ services:
       - avenu-internal
   backend:
     image: ${IMAGE_NAMESPACE:-chunkitw}/avenu-backend:latest
+    labels:
+    - "com.centurylinklabs.watchtower.enable=true"
     env_file:
       - .env
     environment:
@@ -86,6 +90,8 @@ services:
       - avenu-internal
   scheduler:
     image: ${IMAGE_NAMESPACE:-chunkitw}/avenu-scheduler:latest
+    labels:
+    - "com.centurylinklabs.watchtower.enable=true"
     environment:
       BACKEND_API_URL: http://backend:8000
       SCHEDULER_INTERNAL_TOKEN: ${SCHEDULER_INTERNAL_TOKEN}
@@ -96,6 +102,15 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+    networks:
+      - avenu-internal
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 300 --cleanup
     networks:
       - avenu-internal
 networks:
@@ -116,7 +131,3 @@ volumes:
       device: ${PROMETHEUS_CONFIG_DIR:-/mnt/Main/other/PrometheusMailEtc/}
   grafana-data:
     driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ${GRAFANA_DATA_DIR:-/mnt/Main/other/GrafanaMail/}


### PR DESCRIPTION
## Summary

Production previously depended on manual steps (for example Dockge **Update**) to pull new images from Docker Hub and restart app containers, which added operational overhead and made it easier to lag behind published images.

This change adds **Watchtower** to the production Compose stack so **frontend**, **backend**, and **scheduler** are polled and recreated when newer images are available on the registry, without a manual pull/redeploy for routine releases.

Closes #110 

## Problem

- Compose does not refresh running containers when a tag like `:latest` is updated on Docker Hub.
- Operators had to intervene to align running services with published images.
- That increased delay and inconsistency between Hub and what was actually running.

## Solution

- Added a `watchtower` service (`containrrr/watchtower`) with access to the host Docker socket, `--interval 300` (5 minute poll), and `--cleanup` to remove replaced image layers.
- Labeled **only** `frontend`, `backend`, and `scheduler` with `com.centurylinklabs.watchtower.enable=true` so Prometheus, Grafana, and Watchtower itself are not auto-updated by Watchtower.

## Documentation

- Updated `README.md` production topology and rollout guidance: Watchtower’s role, poll interval, and when Dockge is still needed (compose / `.env` / first bring-up).

## Expected outcome

- Containers for the three app images update automatically after Hub publishes new digests for the configured tags.
- Less manual deployment work for image-only rollouts.
- Tighter consistency between Docker Hub and running services (within the poll interval).