### PR TITLE
Migrate container publishing from Docker Hub to GHCR

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,7 +41,8 @@ SCHEDULER_TIMEZONE=America/New_York
 SCHEDULER_TICK_SECONDS=20
 
 # Production-only compose helpers for docker-compose-prod.yml
-IMAGE_NAMESPACE=chunkitw
+IMAGE_REGISTRY=ghcr.io
+IMAGE_OWNER=cmu-413
 GRAFANA_ADMIN_PASSWORD=changeme
 GRAFANA_ROOT_URL=https://hub.avenuworkspaces.com/mail/grafana
 PROMETHEUS_DATA_DIR=/mnt/Main/other/PrometheusMail/

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -174,7 +174,7 @@ jobs:
         run: python -m unittest discover -s tests/integration -t .
 
   deploy:
-    name: docker build & push
+    name: build & push GHCR images
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-changes.outputs.any_changed == 'true'
     needs: [build, backend-integration, detect-changes]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -178,6 +178,12 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-changes.outputs.any_changed == 'true'
     needs: [build, backend-integration, detect-changes]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_OWNER: cmu-413
 
     strategy:
       matrix: ${{ fromJSON(needs.detect-changes.outputs.deploy_matrix) }}
@@ -188,11 +194,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build & Push
         uses: docker/build-push-action@v5
@@ -201,5 +208,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            chunkitw/avenu-${{ matrix.service }}:latest
-            chunkitw/avenu-${{ matrix.service }}:sha-${{ github.sha }}
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_OWNER }}/avenu-${{ matrix.service }}:latest
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_OWNER }}/avenu-${{ matrix.service }}:sha-${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Scheduler runtime variables:
 
 Production-only Compose conveniences:
 
-- `IMAGE_NAMESPACE` controls the Docker Hub namespace used by `docker-compose-prod.yml`
+- `IMAGE_REGISTRY` and `IMAGE_OWNER` control the production image references used by `docker-compose-prod.yml`
 - `PROMETHEUS_DATA_DIR`, `PROMETHEUS_CONFIG_DIR`, and `GRAFANA_DATA_DIR` map host storage into containers
 - `GRAFANA_ROOT_URL` must match the public subpath used by nginx
 - `GRAFANA_ADMIN_PASSWORD` sets the Grafana admin password
@@ -219,17 +219,20 @@ GitHub Actions runs:
 - scheduler tests
 - frontend lint, type-check, and build
 
-On `main`, CI builds and pushes application images to Docker Hub.
+On `main`, CI builds and pushes application images to GitHub Container Registry (GHCR).
 
 Current implementation detail:
 
-- CI currently pushes to the `chunkitw` namespace in [`.github/workflows/ci-cd.yml`](.github/workflows/ci-cd.yml).
-- Production Compose now supports `IMAGE_NAMESPACE`, but CI still needs to be updated manually if image ownership moves to another account or organization.
+- CI publishes changed service images to:
+  - `ghcr.io/cmu-413/avenu-backend`
+  - `ghcr.io/cmu-413/avenu-frontend`
+  - `ghcr.io/cmu-413/avenu-scheduler`
+- Each published image keeps both `latest` and `sha-<git-sha>` tags.
+- The workflow authenticates to GHCR with `GITHUB_TOKEN`, so no Docker Hub credentials are required.
 
 Required GitHub secrets:
 
-- `DOCKERHUB_USERNAME`
-- `DOCKERHUB_TOKEN`
+- None beyond the default `GITHUB_TOKEN` available to GitHub Actions.
 
 ## Production Deployment and Dockge Rollout
 
@@ -239,7 +242,7 @@ Required GitHub secrets:
 
 Production uses:
 
-- Docker Hub images for `frontend`, `backend`, and `scheduler`
+- GHCR images for `frontend`, `backend`, and `scheduler`
 - a Dockge-managed `docker-compose-prod.yml` stack
 - Watchtower in the same stack: it polls the registry on a fixed interval (currently 300 seconds in `docker-compose-prod.yml`) and recreates containers when newer images are available. The application services carry `com.centurylinklabs.watchtower.enable=true` labels so only those images are watched.
 - host nginx routing public traffic to the internal container ports
@@ -248,7 +251,9 @@ Production uses:
 
 ### Before First Rollout
 
-1. Set the Docker Hub namespace in Dockge `.env` with `IMAGE_NAMESPACE`.
+1. Set the image registry in Dockge `.env` with:
+   - `IMAGE_REGISTRY=ghcr.io`
+   - `IMAGE_OWNER=cmu-413`
 2. Set all backend and scheduler runtime secrets in Dockge `.env`.
 3. Set host storage paths for:
    - `PROMETHEUS_DATA_DIR`
@@ -259,6 +264,9 @@ Production uses:
    - `/mail -> frontend :18080`
    - `/mail/api -> backend :18000`
    - `/mail/grafana -> frontend proxy -> grafana`
+6. Ensure production hosts can pull from GHCR:
+   - if the packages are public, no host login is required
+   - if the packages are private, run `docker login ghcr.io` on the host with a token that has `read:packages`
 
 ### Frontend Build-Time Rules
 
@@ -275,26 +283,26 @@ If building manually, publish `linux/amd64` images:
 Backend:
 
 ```bash
-docker buildx build --platform linux/amd64 -t <namespace>/avenu-backend:latest --push ./backend
+docker buildx build --platform linux/amd64 -t <registry>/<owner>/avenu-backend:latest --push ./backend
 ```
 
 Frontend:
 
 ```bash
-docker buildx build --platform linux/amd64 -t <namespace>/avenu-frontend:latest --push ./frontend
+docker buildx build --platform linux/amd64 -t <registry>/<owner>/avenu-frontend:latest --push ./frontend
 ```
 
 Scheduler:
 
 ```bash
-docker buildx build --platform linux/amd64 -t <namespace>/avenu-scheduler:latest --push ./scheduler
+docker buildx build --platform linux/amd64 -t <registry>/<owner>/avenu-scheduler:latest --push ./scheduler
 ```
 
-Replace `<namespace>` with the Docker Hub account or org that owns the images. The sample production Compose defaults to `chunkitw`, but future maintainers should treat that as an overrideable placeholder, not a permanent constant.
+Replace `<registry>/<owner>` with the registry and org that own the images. The production defaults are `ghcr.io/cmu-413`.
 
 ### Image rollout and Dockge
 
-After CI (or a maintainer) publishes new `frontend`, `backend`, or `scheduler` images to Docker Hub, Watchtower detects newer tags on its poll interval and replaces those containers automatically. You do not need to open Dockge and click **Update** for routine image-only rollouts.
+After CI (or a maintainer) publishes new `frontend`, `backend`, or `scheduler` images to GHCR, Watchtower detects newer tags on its poll interval and replaces those containers automatically. You do not need to open Dockge and click **Update** for routine image-only rollouts.
 
 Use Dockge when something outside Watchtower’s scope changes, for example:
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   frontend:
-    image: ${IMAGE_NAMESPACE:-chunkitw}/avenu-frontend:latest
+    image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_OWNER:-cmu-413}/avenu-frontend:latest
     labels:
     - "com.centurylinklabs.watchtower.enable=true"
     ports:
@@ -12,7 +12,7 @@ services:
     networks:
       - avenu-internal
   backend:
-    image: ${IMAGE_NAMESPACE:-chunkitw}/avenu-backend:latest
+    image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_OWNER:-cmu-413}/avenu-backend:latest
     labels:
     - "com.centurylinklabs.watchtower.enable=true"
     env_file:
@@ -89,7 +89,7 @@ services:
     networks:
       - avenu-internal
   scheduler:
-    image: ${IMAGE_NAMESPACE:-chunkitw}/avenu-scheduler:latest
+    image: ${IMAGE_REGISTRY:-ghcr.io}/${IMAGE_OWNER:-cmu-413}/avenu-scheduler:latest
     labels:
     - "com.centurylinklabs.watchtower.enable=true"
     environment:

--- a/docs/02-plans/plan-docs-readme-deployment-alignment.md
+++ b/docs/02-plans/plan-docs-readme-deployment-alignment.md
@@ -22,9 +22,9 @@ Summary of changes per file:
 - `README.md`
   - Rework the doc into the primary onboarding and deployment guide.
   - Document local development, test commands, production image publishing, Dockge rollout, verification, and current service topology.
-  - Call out the Docker Hub namespace as maintainer-owned configuration that must be replaced when ownership changes.
+  - Call out production image registry and owner as explicit configuration instead of hardcoded maintainer-owned Docker Hub namespace.
 - `docker-compose-prod.yml`
-  - Replace hardcoded application image namespaces with a single configurable namespace variable so the documented rollout matches the file future maintainers will edit.
+  - Replace hardcoded application image namespaces with configurable registry and owner variables so the documented rollout matches the file future maintainers will edit.
 
 Inline unit tests:
 - None; documentation and Compose configuration only.

--- a/docs/02-plans/plan-migrate-container-publishing-to-ghcr.md
+++ b/docs/02-plans/plan-migrate-container-publishing-to-ghcr.md
@@ -1,0 +1,76 @@
+# Open Questions
+- None.
+
+# Locked Decisions
+- `main` publishes to GHCR only; Docker Hub is not retained as a transition publish target.
+- Production image configuration uses explicit `IMAGE_REGISTRY` and `IMAGE_OWNER` variables.
+
+# Task Checklist
+## Phase 1
+- ☑ Switch CI publishing from Docker Hub auth and tags to GHCR auth and tags.
+- ☑ Preserve `latest` and `sha-<git-sha>` tags for each published service image.
+- ☑ Remove Docker Hub secret requirements from the documented CI contract.
+
+## Phase 2
+- ☑ Rework production image references to point at GHCR-owned images.
+- ☑ Align sample env/config variables with the chosen image-reference model.
+- ☑ Document any required GHCR package visibility or host pull-auth setup for Dockge.
+
+## Phase 3
+- ☑ Remove Docker Hub as the canonical registry from deployment and publishing docs.
+- ☑ Either remove stale Docker Hub references or mark intentional temporary transition behavior explicitly.
+
+## Phase 1
+
+Affected files:
+- `.github/workflows/ci-cd.yml`
+- `README.md`
+
+Summary of changes per file:
+- `.github/workflows/ci-cd.yml`
+  - Add `packages: write` permission for the publish job path.
+  - Replace Docker Hub login with GHCR login using `${{ github.actor }}` and `${{ secrets.GITHUB_TOKEN }}`.
+  - Publish changed service images to `ghcr.io/cmu-413/avenu-backend`, `ghcr.io/cmu-413/avenu-frontend`, and `ghcr.io/cmu-413/avenu-scheduler`.
+  - Preserve both `latest` and `sha-${{ github.sha }}` tags for each service.
+- `README.md`
+  - Update the CI publishing section to describe GHCR as the default registry and remove Docker Hub credential setup from the required GitHub secrets list.
+
+Inline unit tests:
+- None; workflow and documentation changes only.
+
+## Phase 2
+
+Affected files:
+- `docker-compose-prod.yml`
+- `.env.sample`
+- `README.md`
+
+Summary of changes per file:
+- `docker-compose-prod.yml`
+  - Replace Docker Hub image defaults with GHCR image references for `frontend`, `backend`, and `scheduler`.
+  - Switch the Compose image references to `IMAGE_REGISTRY` and `IMAGE_OWNER` so registry changes do not require string-shape changes.
+- `.env.sample`
+  - Replace `IMAGE_NAMESPACE=chunkitw` with `IMAGE_REGISTRY=ghcr.io` and `IMAGE_OWNER=cmu-413`.
+  - Add only the minimal comments needed to show how production hosts should point Dockge at `ghcr.io/cmu-413`.
+- `README.md`
+  - Update production rollout instructions, manual publish examples, and rollback guidance to use GHCR image names and tags.
+  - Document the production requirement for package visibility and any needed `docker login ghcr.io` or token setup on pull hosts if images are not public.
+
+Inline unit tests:
+- None; Compose, env example, and documentation changes only.
+
+## Phase 3
+
+Affected files:
+- `README.md`
+- `docs/02-plans/plan-docs-readme-deployment-alignment.md`
+
+Summary of changes per file:
+- `README.md`
+  - Remove Docker Hub as the canonical publish and deploy path.
+  - Make GHCR-only publishing explicit and remove temporary-transition language that implies Docker Hub remains active.
+- `docs/02-plans/plan-docs-readme-deployment-alignment.md`
+  - Update the stale planning reference that currently describes Docker Hub namespace ownership so the plan set stays aligned with GHCR as the target registry.
+
+Inline unit tests:
+- None; documentation-only changes.


### PR DESCRIPTION
## Problem

Avenu container publishing still targets a personal Docker Hub namespace and depends on Docker Hub credentials in GitHub Actions. That leaves image ownership, CI publishing, and deployment pulls coupled to infrastructure outside the `CMU-413` GitHub org.

Impact: this makes ownership changes brittle, keeps production tied to a personal registry namespace, and prevents Actions from using the default GitHub package publishing flow.

## Solution

Switch the publish pipeline from Docker Hub to GHCR and align production configuration with explicit registry and owner variables. The deploy job now logs into `ghcr.io` with `GITHUB_TOKEN`, publishes `latest` and `sha-<git-sha>` tags for each changed service image, and no longer depends on Docker Hub secrets.

On the deployment side, production image references now use `IMAGE_REGISTRY` and `IMAGE_OWNER` instead of a Docker-Hub-specific namespace variable. The README and sample env file were updated so Dockge and production hosts are configured against GHCR as the canonical registry.

A temporary dual-publish path was not kept. This keeps the migration simple and avoids leaving two canonical registries in circulation.

## Risks

Merge readiness still depends on external setup outside this branch:
- GHCR package publishing must be allowed by the repo/org Actions settings.
- The `ghcr.io/cmu-413/avenu-*` packages must be made public, or production hosts must authenticate with a token that has `read:packages`.
- Dockge production env must be updated to `IMAGE_REGISTRY=ghcr.io` and `IMAGE_OWNER=cmu-413` before relying on new publishes.

The code change itself is low risk because it is limited to workflow, Compose, env example, and documentation updates.

## Related

Closes #108 

---

## Reviewer Notes

Please review the GHCR publish job permissions and tag format closely. Before merging, confirm the org/repo can publish packages, decide package visibility, and verify the production host or Dockge environment is ready to pull from GHCR.
