### PR TITLE
Feat/ocr image staging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -40,6 +40,13 @@ FEATURE_ADMIN_OCR=false
 FEATURE_OCR_QUEUE_V2=false
 FEATURE_OCR_SHADOW_LAUNCH=false
 OCR_SHADOW_PROVIDER=
+# When true, uploaded queue images are OCR'd automatically in the background; when false they
+# land as `pending` for manual review on the admin OCR queue page. Requires FEATURE_ADMIN_OCR.
+FEATURE_OCR_AUTO_EXTRACT=false
+
+# Local photo staging: uploaded queue images are written here (bind-mounted into backend),
+# and anything older than the retention window is pruned nightly by the scheduler.
+IMAGE_RETENTION_HOURS=24
 
 OCR_PROVIDER=paddleocr
 # OCR_PROVIDER: paddleocr (self-hosted, default), easyocr, tesseract, or ocrspace (external API)
@@ -48,6 +55,7 @@ OCR_SPACE_API_KEY=
 
 BACKEND_API_URL=http://backend:8000
 SCHEDULER_CRON=0 8 * * 1
+IMAGE_PRUNE_CRON=0 3 * * *
 SCHEDULER_TIMEZONE=America/New_York
 SCHEDULER_TICK_SECONDS=20
 
@@ -59,3 +67,6 @@ GRAFANA_ROOT_URL=https://hub.avenuworkspaces.com/mail/grafana
 PROMETHEUS_DATA_DIR=/mnt/Main/other/PrometheusMail/
 PROMETHEUS_CONFIG_DIR=/mnt/Main/other/PrometheusMailEtc/
 GRAFANA_DATA_DIR=/mnt/Main/other/GrafanaMail/
+# Host directory bind-mounted into backend at /var/lib/avenu/images. Must exist and be
+# writable by the backend container uid. Pruned nightly per IMAGE_PRUNE_CRON + IMAGE_RETENTION_HOURS.
+MAIL_IMAGES_DIR=/mnt/Main/other/AvenuMailImages/

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -75,6 +75,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true'
+    # Guard against hanging tests eating the whole runner budget; a healthy
+    # build job finishes in a few minutes.
+    timeout-minutes: 15
 
     strategy:
       matrix: ${{ fromJSON(needs.detect-changes.outputs.build_matrix) }}

--- a/backend/config.py
+++ b/backend/config.py
@@ -79,12 +79,22 @@ FEATURE_OCR_QUEUE_V2 = _env_bool("FEATURE_OCR_QUEUE_V2", False)
 FEATURE_OCR_SHADOW_LAUNCH = _env_bool("FEATURE_OCR_SHADOW_LAUNCH", False)
 OCR_SHADOW_PROVIDER = os.getenv("OCR_SHADOW_PROVIDER", "").strip().lower() or None
 
+# When true, uploaded images are OCR'd in a background thread; when false, items land as
+# `pending` for manual review. OCR auto-sort is descoped; default off.
+FEATURE_OCR_AUTO_EXTRACT = _env_bool("FEATURE_OCR_AUTO_EXTRACT", False)
+
+# Host-mounted directory where uploaded mail photos live (see docker-compose volumes).
+IMAGE_STORE_DIR = os.getenv("IMAGE_STORE_DIR", "/var/lib/avenu/images").strip() or "/var/lib/avenu/images"
+# Nightly prune deletes anything older than this many hours (both files and queue rows).
+IMAGE_RETENTION_HOURS = _env_positive_int("IMAGE_RETENTION_HOURS", 24)
+
 
 def get_feature_flags() -> dict[str, bool]:
     return {
         "adminOcr": FEATURE_ADMIN_OCR,
         "ocrQueueV2": FEATURE_OCR_QUEUE_V2 and FEATURE_ADMIN_OCR,
         "ocrShadowLaunch": FEATURE_OCR_SHADOW_LAUNCH and FEATURE_ADMIN_OCR,
+        "ocrAutoExtract": FEATURE_OCR_AUTO_EXTRACT and FEATURE_ADMIN_OCR,
     }
 
 

--- a/backend/controllers/internal_jobs_controller.py
+++ b/backend/controllers/internal_jobs_controller.py
@@ -8,6 +8,7 @@ from config import SCHEDULER_INTERNAL_TOKEN
 from controllers.common import parse_iso_date
 from errors import APIError
 from services.idempotency_service import begin_request, commit_response, rollback_reservation
+from services.image_pruner import prune_expired_images
 from services.notifications.channels.factory import build_notification_channels
 from services.notifications.weekly_summary_cron_job import run_weekly_summary_cron_job
 from services.notifications.weekly_summary_notifier import WeeklySummaryNotifier
@@ -79,6 +80,39 @@ def internal_weekly_summary_job_route():
             week_end=week_end,
         )
         body = _weekly_job_response_body(result)
+        commit_response(key=idempotency_key, route=route, method="POST", status=200, body=body)
+        return jsonify(body), 200
+    except Exception:
+        rollback_reservation(key=idempotency_key, route=route, method="POST")
+        raise
+
+
+@internal_jobs_bp.route("/api/internal/jobs/image-prune", methods=["POST"])
+def internal_image_prune_job_route():
+    _require_scheduler_token()
+
+    body_raw = request.get_json(silent=True)
+    payload = {} if body_raw is None else require_dict(body_raw)
+    retention_override = payload.get("retentionHours")
+    retention_hours: int | None = None
+    if retention_override is not None:
+        if not isinstance(retention_override, int) or isinstance(retention_override, bool) or retention_override <= 0:
+            raise APIError(422, "retentionHours must be a positive integer")
+        retention_hours = retention_override
+
+    route = "/api/internal/jobs/image-prune"
+    idempotency_key, replay = begin_request(
+        headers=request.headers,
+        payload=payload,
+        route=route,
+        method="POST",
+    )
+    if replay is not None:
+        return jsonify(replay["body"]), replay["status"]
+
+    try:
+        result = prune_expired_images(retention_hours=retention_hours)
+        body = result.to_dict()
         commit_response(key=idempotency_key, route=route, method="POST", status=200, body=body)
         return jsonify(body), 200
     except Exception:

--- a/backend/controllers/ocr_queue_controller.py
+++ b/backend/controllers/ocr_queue_controller.py
@@ -10,7 +10,14 @@ from typing import Any
 from bson import ObjectId
 from flask import Blueprint, jsonify, request, send_file
 
-from config import FEATURE_ADMIN_OCR, FEATURE_OCR_QUEUE_V2, OCR_MAX_FILE_BYTES, ocr_queue_items_collection, fs
+from config import (
+    FEATURE_ADMIN_OCR,
+    FEATURE_OCR_AUTO_EXTRACT,
+    FEATURE_OCR_QUEUE_V2,
+    OCR_MAX_FILE_BYTES,
+    fs,
+    ocr_queue_items_collection,
+)
 from controllers.auth_guard import require_admin_session
 from errors import APIError
 from idempotency import payload_hash
@@ -28,6 +35,7 @@ from repositories.ocr_queue_repository import (
 )
 from repositories import to_api_doc
 from metrics.metrics_ocr import mail_image_ocr_metrics
+from services import image_store
 from services.mail_service import create_mail
 from services.ocr.ocr_parser import has_identified_receiver, parse_ocr_text_with_metadata
 
@@ -131,6 +139,7 @@ def _serialize_item(doc: dict[str, Any]) -> dict:
         "error": doc.get("error"),
         "mailboxId": str(doc["mailboxId"]) if doc.get("mailboxId") else None,
         "fileId": str(doc["fileId"]) if doc.get("fileId") else None,
+        "imagePath": doc.get("imagePath"),
         "confirmedAt": doc["confirmedAt"].isoformat() if doc.get("confirmedAt") else None,
     }
 
@@ -167,27 +176,34 @@ def create_job():
     if not image_payloads:
         raise APIError(422, "no valid images to process")
 
-    # Store images in GridFS
-    file_ids: list[ObjectId] = []
-    for img_data, content_type in image_payloads:
-        fid = fs.put(img_data, content_type=content_type, filename="ocr_upload")
-        file_ids.append(fid)
+    image_paths: list[str] = [
+        image_store.save_bytes(img_data, content_type)
+        for img_data, content_type in image_payloads
+    ]
 
     date = request.form.get("date") or datetime.utcnow().strftime("%Y-%m-%d")
 
     job_id = create_ocr_job(created_by=admin_id, date=date, item_count=len(image_payloads))
-    create_ocr_queue_items(job_id, len(image_payloads), file_ids=file_ids)
+    create_ocr_queue_items(job_id, len(image_payloads), image_paths=image_paths)
 
-    from flask import current_app
-    app = current_app._get_current_object()
-    thread = threading.Thread(target=_process_ocr_job, args=(app, job_id, image_payloads), daemon=True)
-    thread.start()
+    if FEATURE_OCR_AUTO_EXTRACT:
+        from flask import current_app
+        app = current_app._get_current_object()
+        thread = threading.Thread(target=_process_ocr_job, args=(app, job_id, image_payloads), daemon=True)
+        thread.start()
+        status = "processing"
+    else:
+        # Auto-extract is off: items stay `pending`; admin fills in receiver/sender
+        # manually during review. Mark the job itself as processed so the UI stops
+        # showing a spinner — there's no background work to wait for.
+        update_ocr_job_status(job_id, "processed", completed_count=len(image_payloads))
+        status = "processed"
 
     return jsonify({
         "id": str(job_id),
-        "status": "processing",
+        "status": status,
         "totalCount": len(image_payloads),
-        "completedCount": 0,
+        "completedCount": len(image_payloads) if not FEATURE_OCR_AUTO_EXTRACT else 0,
         "date": date,
     }), 201
 
@@ -358,19 +374,35 @@ def update_job_stage(job_id: str):
 @ocr_queue_bp.route("/api/ocr/queue/<item_id>/image", methods=["GET"])
 @require_admin_session
 def get_item_image(item_id: str):
-    """Get the image for a queue item."""
+    """Stream the image for a queue item.
+
+    Prefers the filesystem path (new uploads). Falls back to GridFS for any
+    legacy items written before the volume-backed store existed.
+    """
     if not ObjectId.is_valid(item_id):
         raise APIError(404, "item not found")
-    
-    item = get_ocr_queue_item(ObjectId(item_id))
-    if not item or not item.get("fileId"):
-        raise APIError(404, "image not found")
 
-    try:
-        grid_out = fs.get(item["fileId"])
-        return send_file(grid_out, mimetype=grid_out.content_type)
-    except Exception:
-        raise APIError(404, "image file missing")
+    item = get_ocr_queue_item(ObjectId(item_id))
+    if not item:
+        raise APIError(404, "item not found")
+
+    rel_path = item.get("imagePath")
+    if rel_path:
+        try:
+            stream, content_type = image_store.open_path(rel_path)
+        except FileNotFoundError:
+            raise APIError(404, "image file missing")
+        return send_file(stream, mimetype=content_type)
+
+    file_id = item.get("fileId")
+    if file_id:
+        try:
+            grid_out = fs.get(file_id)
+            return send_file(grid_out, mimetype=grid_out.content_type)
+        except Exception:
+            raise APIError(404, "image file missing")
+
+    raise APIError(404, "image not found")
 
 
 @ocr_queue_bp.route("/api/ocr/jobs", methods=["OPTIONS"], endpoint="ocr_jobs_options")

--- a/backend/repositories/ocr_queue_repository.py
+++ b/backend/repositories/ocr_queue_repository.py
@@ -24,7 +24,13 @@ def create_ocr_job(*, created_by: ObjectId, date: str, item_count: int) -> Objec
     return r.inserted_id
 
 
-def create_ocr_queue_items(job_id: ObjectId, count: int, file_ids: list[ObjectId] | None = None) -> list[ObjectId]:
+def create_ocr_queue_items(
+    job_id: ObjectId,
+    count: int,
+    *,
+    file_ids: list[ObjectId] | None = None,
+    image_paths: list[str] | None = None,
+) -> list[ObjectId]:
     now = datetime.utcnow()
     docs = [
         {
@@ -38,6 +44,7 @@ def create_ocr_queue_items(job_id: ObjectId, count: int, file_ids: list[ObjectId
             "error": None,
             "mailboxId": None,
             "fileId": file_ids[i] if file_ids and i < len(file_ids) else None,
+            "imagePath": image_paths[i] if image_paths and i < len(image_paths) else None,
             "confirmedAt": None,
             "createdAt": now,
             "updatedAt": now,

--- a/backend/services/image_pruner.py
+++ b/backend/services/image_pruner.py
@@ -1,0 +1,99 @@
+"""Nightly prune: drop image files + their queue rows once past retention.
+
+Composition is the whole point here: we take the list of stale rows from
+Mongo, unlink their files via :mod:`image_store`, then soft-delete the rows.
+The store walk is also run so any dangling files (uploads whose row was
+purged separately, or files whose path was lost) don't linger.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable, Iterable
+
+from config import IMAGE_RETENTION_HOURS, ocr_queue_items_collection
+from services import image_store
+
+
+@dataclass(frozen=True)
+class PruneResult:
+    rows_scanned: int
+    files_deleted: int
+    rows_marked_deleted: int
+    orphan_files_deleted: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "rowsScanned": self.rows_scanned,
+            "filesDeleted": self.files_deleted,
+            "rowsMarkedDeleted": self.rows_marked_deleted,
+            "orphanFilesDeleted": self.orphan_files_deleted,
+        }
+
+
+def prune_expired_images(
+    *,
+    retention_hours: int | None = None,
+    now: datetime | None = None,
+    find_stale: Callable[[datetime], Iterable[dict]] | None = None,
+    mark_deleted: Callable[[list], int] | None = None,
+    delete_file: Callable[[str], bool] | None = None,
+    prune_orphans: Callable[[int], int] | None = None,
+) -> PruneResult:
+    """Delete images (and their queue rows) older than retention.
+
+    Dependency-injected for testability; production defaults hit Mongo + the
+    filesystem store.
+    """
+    hours = retention_hours if retention_hours is not None else IMAGE_RETENTION_HOURS
+    current = now or datetime.utcnow()
+    cutoff = current - timedelta(hours=hours)
+    retention_seconds = hours * 3600
+
+    _find_stale = find_stale or _default_find_stale
+    _mark = mark_deleted or _default_mark_deleted
+    _delete_file = delete_file or image_store.delete_path
+    _prune_orphans = prune_orphans or image_store.prune_older_than
+
+    stale_rows = list(_find_stale(cutoff))
+    files_deleted = 0
+    deletable_ids: list = []
+    for row in stale_rows:
+        deletable_ids.append(row["_id"])
+        path = row.get("imagePath")
+        if path and _delete_file(path):
+            files_deleted += 1
+
+    rows_marked = _mark(deletable_ids) if deletable_ids else 0
+    orphan_count = _prune_orphans(retention_seconds)
+
+    return PruneResult(
+        rows_scanned=len(stale_rows),
+        files_deleted=files_deleted,
+        rows_marked_deleted=rows_marked,
+        orphan_files_deleted=orphan_count,
+    )
+
+
+def _default_find_stale(cutoff: datetime) -> Iterable[dict]:
+    # Rows with an imagePath created before the cutoff, not already soft-deleted.
+    cursor = ocr_queue_items_collection.find(
+        {
+            "imagePath": {"$ne": None},
+            "status": {"$ne": "deleted"},
+            "createdAt": {"$lt": cutoff},
+        },
+        {"_id": 1, "imagePath": 1},
+    )
+    return cursor
+
+
+def _default_mark_deleted(ids: list) -> int:
+    if not ids:
+        return 0
+    result = ocr_queue_items_collection.update_many(
+        {"_id": {"$in": ids}},
+        {"$set": {"status": "deleted", "imagePath": None, "updatedAt": datetime.utcnow()}},
+    )
+    return result.modified_count

--- a/backend/services/image_store.py
+++ b/backend/services/image_store.py
@@ -1,0 +1,107 @@
+"""Filesystem-backed image store for mail photos.
+
+Purely-stdlib module; no Mongo, no Flask. Images live under
+``IMAGE_STORE_DIR`` (typically a host-bind-mounted Docker volume). The module
+exposes a small, value-oriented surface: bytes + content-type go in, a
+relative path comes out; paths later resolve back to streams. The store does
+not track metadata; callers (the queue layer) persist ``imagePath`` on their
+own documents.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import BinaryIO, Iterator
+
+_DEFAULT_EXT = ".bin"
+_CONTENT_TYPE_EXTENSIONS: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/tiff": ".tif",
+    "image/bmp": ".bmp",
+}
+
+
+def _ext_for(content_type: str) -> str:
+    ct = (content_type or "").split(";", 1)[0].strip().lower()
+    return _CONTENT_TYPE_EXTENSIONS.get(ct) or mimetypes.guess_extension(ct) or _DEFAULT_EXT
+
+
+def _ensure_root(root: str) -> Path:
+    path = Path(root)
+    path.mkdir(parents=True, exist_ok=True)
+    return path.resolve()
+
+
+def save_bytes(data: bytes, content_type: str, *, root: str | None = None) -> str:
+    """Write ``data`` under the store root; return the relative path stored on the item."""
+    base = _ensure_root(root or _default_root())
+    ext = _ext_for(content_type)
+    name = f"{secrets.token_hex(12)}{ext}"
+    target = base / name
+    with target.open("wb") as f:
+        f.write(data)
+    return name
+
+
+def open_path(rel_path: str, *, root: str | None = None) -> tuple[BinaryIO, str]:
+    """Open ``rel_path`` for reading; refuses anything resolving outside the store root."""
+    base = _ensure_root(root or _default_root())
+    resolved = (base / rel_path).resolve()
+    if base != resolved and base not in resolved.parents:
+        raise FileNotFoundError(rel_path)
+    if not resolved.is_file():
+        raise FileNotFoundError(rel_path)
+    content_type, _ = mimetypes.guess_type(str(resolved))
+    return resolved.open("rb"), content_type or "application/octet-stream"
+
+
+def delete_path(rel_path: str, *, root: str | None = None) -> bool:
+    """Best-effort unlink; returns True when a file was actually removed."""
+    base = _ensure_root(root or _default_root())
+    resolved = (base / rel_path).resolve()
+    if base != resolved and base not in resolved.parents:
+        return False
+    try:
+        resolved.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+
+
+def prune_older_than(seconds: int, *, root: str | None = None) -> int:
+    """Remove files under the store root whose mtime is older than ``seconds`` ago."""
+    base = _ensure_root(root or _default_root())
+    cutoff = time.time() - max(0, seconds)
+    removed = 0
+    for entry in _iter_files(base):
+        try:
+            if entry.stat().st_mtime < cutoff:
+                entry.unlink()
+                removed += 1
+        except FileNotFoundError:
+            continue
+        except OSError:
+            continue
+    return removed
+
+
+def _iter_files(base: Path) -> Iterator[Path]:
+    for root, _dirs, files in os.walk(base):
+        for name in files:
+            yield Path(root) / name
+
+
+def _default_root() -> str:
+    """Late-bound to avoid import-time coupling with ``config``; tests can override via ``root``."""
+    from config import IMAGE_STORE_DIR
+    return IMAGE_STORE_DIR

--- a/backend/tests/unit/test_image_pruner.py
+++ b/backend/tests/unit/test_image_pruner.py
@@ -1,0 +1,136 @@
+"""Unit tests for the nightly image pruner.
+
+``prune_expired_images`` is pure-function-shaped: all external dependencies
+(Mongo + filesystem) are injected, so tests exercise the composition without
+touching either.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from datetime import datetime, timedelta
+
+os.environ.setdefault("MONGO_URI", "mongodb://localhost:27017")
+
+from services.image_pruner import prune_expired_images
+
+
+class ImagePrunerTests(unittest.TestCase):
+    def test_prune_deletes_stale_rows_and_files(self):
+        now = datetime(2026, 4, 21, 3, 0)
+        stale = [
+            {"_id": "r1", "imagePath": "a.jpg"},
+            {"_id": "r2", "imagePath": "b.png"},
+        ]
+        deleted_files: list[str] = []
+        marked: list[list] = []
+
+        def fake_find(cutoff):
+            self.assertEqual(cutoff, now - timedelta(hours=24))
+            return stale
+
+        def fake_mark(ids):
+            marked.append(ids)
+            return len(ids)
+
+        def fake_delete_file(path):
+            deleted_files.append(path)
+            return True
+
+        def fake_prune_orphans(seconds):
+            self.assertEqual(seconds, 24 * 3600)
+            return 3
+
+        result = prune_expired_images(
+            retention_hours=24,
+            now=now,
+            find_stale=fake_find,
+            mark_deleted=fake_mark,
+            delete_file=fake_delete_file,
+            prune_orphans=fake_prune_orphans,
+        )
+
+        self.assertEqual(deleted_files, ["a.jpg", "b.png"])
+        self.assertEqual(marked, [["r1", "r2"]])
+        self.assertEqual(result.rows_scanned, 2)
+        self.assertEqual(result.files_deleted, 2)
+        self.assertEqual(result.rows_marked_deleted, 2)
+        self.assertEqual(result.orphan_files_deleted, 3)
+
+    def test_prune_skips_rows_without_image_path(self):
+        rows = [{"_id": "r1", "imagePath": None}, {"_id": "r2", "imagePath": "x.jpg"}]
+        file_calls: list[str] = []
+
+        result = prune_expired_images(
+            retention_hours=24,
+            now=datetime(2026, 4, 21),
+            find_stale=lambda _cutoff: rows,
+            mark_deleted=lambda ids: len(ids),
+            delete_file=lambda p: (file_calls.append(p) or True),
+            prune_orphans=lambda _s: 0,
+        )
+
+        self.assertEqual(file_calls, ["x.jpg"])
+        self.assertEqual(result.rows_scanned, 2)
+        self.assertEqual(result.files_deleted, 1)
+        self.assertEqual(result.rows_marked_deleted, 2)
+
+    def test_prune_counts_only_actually_removed_files(self):
+        rows = [{"_id": "r1", "imagePath": "gone.jpg"}, {"_id": "r2", "imagePath": "there.jpg"}]
+
+        def fake_delete(path):
+            return path == "there.jpg"
+
+        result = prune_expired_images(
+            retention_hours=24,
+            now=datetime(2026, 4, 21),
+            find_stale=lambda _c: rows,
+            mark_deleted=lambda ids: len(ids),
+            delete_file=fake_delete,
+            prune_orphans=lambda _s: 0,
+        )
+
+        self.assertEqual(result.files_deleted, 1)
+        self.assertEqual(result.rows_marked_deleted, 2)
+
+    def test_prune_with_no_stale_rows_still_runs_orphan_sweep(self):
+        orphan_calls: list[int] = []
+
+        result = prune_expired_images(
+            retention_hours=12,
+            now=datetime(2026, 4, 21),
+            find_stale=lambda _c: [],
+            mark_deleted=lambda ids: (_ for _ in ()).throw(AssertionError("should not be called")),
+            delete_file=lambda p: True,
+            prune_orphans=lambda s: (orphan_calls.append(s) or 5),
+        )
+
+        self.assertEqual(result.rows_scanned, 0)
+        self.assertEqual(result.files_deleted, 0)
+        self.assertEqual(result.rows_marked_deleted, 0)
+        self.assertEqual(result.orphan_files_deleted, 5)
+        self.assertEqual(orphan_calls, [12 * 3600])
+
+    def test_prune_result_to_dict_uses_camel_case(self):
+        result = prune_expired_images(
+            retention_hours=24,
+            now=datetime(2026, 4, 21),
+            find_stale=lambda _c: [{"_id": "r1", "imagePath": "a.jpg"}],
+            mark_deleted=lambda ids: len(ids),
+            delete_file=lambda _p: True,
+            prune_orphans=lambda _s: 7,
+        )
+        self.assertEqual(
+            result.to_dict(),
+            {
+                "rowsScanned": 1,
+                "filesDeleted": 1,
+                "rowsMarkedDeleted": 1,
+                "orphanFilesDeleted": 7,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_image_store.py
+++ b/backend/tests/unit/test_image_store.py
@@ -1,0 +1,89 @@
+"""Unit tests for the filesystem image store service.
+
+The store is a pure-stdlib module; these tests use a ``tmp_path``-style
+directory to avoid any dependency on MongoDB or the configured
+``IMAGE_STORE_DIR``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+os.environ.setdefault("MONGO_URI", "mongodb://localhost:27017")
+
+from services import image_store
+
+
+class ImageStoreTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.root = self._tmp.name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_save_then_open_round_trips_bytes_and_content_type(self):
+        rel = image_store.save_bytes(b"hello png", "image/png", root=self.root)
+        self.assertTrue(rel.endswith(".png"))
+        stream, content_type = image_store.open_path(rel, root=self.root)
+        try:
+            self.assertEqual(stream.read(), b"hello png")
+        finally:
+            stream.close()
+        self.assertEqual(content_type, "image/png")
+
+    def test_save_uses_content_type_extension(self):
+        jpg = image_store.save_bytes(b"x", "image/jpeg", root=self.root)
+        gif = image_store.save_bytes(b"x", "image/gif", root=self.root)
+        unknown = image_store.save_bytes(b"x", "application/unknown", root=self.root)
+        self.assertTrue(jpg.endswith(".jpg"))
+        self.assertTrue(gif.endswith(".gif"))
+        self.assertTrue(unknown.endswith(".bin"))
+
+    def test_open_path_rejects_traversal(self):
+        image_store.save_bytes(b"x", "image/png", root=self.root)
+        with self.assertRaises(FileNotFoundError):
+            image_store.open_path("../escape.png", root=self.root)
+        with self.assertRaises(FileNotFoundError):
+            image_store.open_path("/etc/passwd", root=self.root)
+
+    def test_open_path_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            image_store.open_path("nonexistent.png", root=self.root)
+
+    def test_delete_path_removes_file(self):
+        rel = image_store.save_bytes(b"x", "image/png", root=self.root)
+        self.assertTrue(image_store.delete_path(rel, root=self.root))
+        self.assertFalse((Path(self.root) / rel).exists())
+
+    def test_delete_path_returns_false_when_missing(self):
+        self.assertFalse(image_store.delete_path("gone.png", root=self.root))
+
+    def test_delete_path_rejects_traversal(self):
+        self.assertFalse(image_store.delete_path("../../etc/passwd", root=self.root))
+
+    def test_prune_older_than_only_deletes_stale_files(self):
+        fresh = image_store.save_bytes(b"fresh", "image/png", root=self.root)
+        stale = image_store.save_bytes(b"stale", "image/png", root=self.root)
+        stale_path = Path(self.root) / stale
+        old_time = time.time() - (3600 * 48)
+        os.utime(stale_path, (old_time, old_time))
+
+        removed = image_store.prune_older_than(3600 * 24, root=self.root)
+
+        self.assertEqual(removed, 1)
+        self.assertFalse((Path(self.root) / stale).exists())
+        self.assertTrue((Path(self.root) / fresh).exists())
+
+    def test_prune_older_than_with_zero_keeps_everything(self):
+        image_store.save_bytes(b"x", "image/png", root=self.root)
+        removed = image_store.prune_older_than(60 * 60 * 24 * 365, root=self.root)
+        self.assertEqual(removed, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/test_ocr_queue_controller.py
+++ b/backend/tests/unit/test_ocr_queue_controller.py
@@ -72,9 +72,8 @@ class UploadValidationTests(_OcrQueueControllerTestBase):
             resp = self.client.post("/api/ocr/jobs", data=data, content_type="multipart/form-data")
         self.assertEqual(resp.status_code, 422)
 
-    def test_post_happy_path_creates_job_and_returns_201(self):
+    def test_post_happy_path_with_auto_extract_off_writes_paths_and_skips_thread(self):
         job_id = ObjectId()
-        file_ids = [ObjectId(), ObjectId()]
 
         data = {
             "files": [
@@ -84,23 +83,49 @@ class UploadValidationTests(_OcrQueueControllerTestBase):
             "date": "2025-01-01",
         }
 
-        with patch("controllers.ocr_queue_controller.fs") as fs_mock, \
+        saved_paths = ["abc.jpg", "def.png"]
+        with patch("controllers.ocr_queue_controller.FEATURE_OCR_AUTO_EXTRACT", False), \
+             patch("controllers.ocr_queue_controller.image_store.save_bytes", side_effect=saved_paths) as save_mock, \
              patch("controllers.ocr_queue_controller.create_ocr_job", return_value=job_id) as create_job, \
              patch("controllers.ocr_queue_controller.create_ocr_queue_items", return_value=[ObjectId(), ObjectId()]) as create_items, \
+             patch("controllers.ocr_queue_controller.update_ocr_job_status") as status_mock, \
              patch("controllers.ocr_queue_controller.threading.Thread") as thread_mock:
-            fs_mock.put.side_effect = file_ids
             resp = self.client.post("/api/ocr/jobs", data=data, content_type="multipart/form-data")
 
         self.assertEqual(resp.status_code, 201)
         body = resp.get_json()
         self.assertEqual(body["id"], str(job_id))
-        self.assertEqual(body["status"], "processing")
+        self.assertEqual(body["status"], "processed")
         self.assertEqual(body["totalCount"], 2)
-        self.assertEqual(body["completedCount"], 0)
+        self.assertEqual(body["completedCount"], 2)
         self.assertEqual(body["date"], "2025-01-01")
         create_job.assert_called_once()
         create_items.assert_called_once()
+        self.assertEqual(create_items.call_args.kwargs["image_paths"], saved_paths)
+        self.assertEqual(save_mock.call_count, 2)
+        status_mock.assert_called_once_with(job_id, "processed", completed_count=2)
+        thread_mock.assert_not_called()
+
+    def test_post_happy_path_with_auto_extract_on_starts_thread(self):
+        job_id = ObjectId()
+        data = {
+            "files": [(io.BytesIO(b"img"), "a.jpg", "image/jpeg")],
+            "date": "2025-01-01",
+        }
+        with patch("controllers.ocr_queue_controller.FEATURE_OCR_AUTO_EXTRACT", True), \
+             patch("controllers.ocr_queue_controller.image_store.save_bytes", return_value="xyz.jpg"), \
+             patch("controllers.ocr_queue_controller.create_ocr_job", return_value=job_id), \
+             patch("controllers.ocr_queue_controller.create_ocr_queue_items", return_value=[ObjectId()]), \
+             patch("controllers.ocr_queue_controller.update_ocr_job_status") as status_mock, \
+             patch("controllers.ocr_queue_controller.threading.Thread") as thread_mock:
+            resp = self.client.post("/api/ocr/jobs", data=data, content_type="multipart/form-data")
+
+        self.assertEqual(resp.status_code, 201)
+        body = resp.get_json()
+        self.assertEqual(body["status"], "processing")
+        self.assertEqual(body["completedCount"], 0)
         thread_mock.return_value.start.assert_called_once()
+        status_mock.assert_not_called()
 
 
 class QueueItemPatchTests(_OcrQueueControllerTestBase):
@@ -263,6 +288,62 @@ class ConfirmFlowTests(_OcrQueueControllerTestBase):
             with self.assertRaises(RuntimeError):
                 self.client.post(f"/api/ocr/queue/{item['_id']}/confirm")
         release.assert_called_once()
+
+
+class GetItemImageTests(_OcrQueueControllerTestBase):
+    def test_get_image_prefers_filesystem_when_path_present(self):
+        item_id = ObjectId()
+        item = {"_id": item_id, "imagePath": "abc.jpg", "fileId": None}
+        stream = io.BytesIO(b"pixels")
+        with patch("controllers.ocr_queue_controller.get_ocr_queue_item", return_value=item), \
+             patch("controllers.ocr_queue_controller.image_store.open_path",
+                   return_value=(stream, "image/jpeg")) as open_mock, \
+             patch("controllers.ocr_queue_controller.fs") as fs_mock:
+            resp = self.client.get(f"/api/ocr/queue/{item_id}/image")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, b"pixels")
+        self.assertEqual(resp.mimetype, "image/jpeg")
+        open_mock.assert_called_once_with("abc.jpg")
+        fs_mock.get.assert_not_called()
+
+    def test_get_image_falls_back_to_gridfs_when_no_path(self):
+        item_id = ObjectId()
+        file_id = ObjectId()
+        item = {"_id": item_id, "imagePath": None, "fileId": file_id}
+
+        class _FakeGrid:
+            content_type = "image/png"
+            def read(self, n=-1):
+                return b"legacy"
+            def close(self):
+                pass
+
+        with patch("controllers.ocr_queue_controller.get_ocr_queue_item", return_value=item), \
+             patch("controllers.ocr_queue_controller.image_store.open_path") as open_mock, \
+             patch("controllers.ocr_queue_controller.fs") as fs_mock:
+            fs_mock.get.return_value = _FakeGrid()
+            resp = self.client.get(f"/api/ocr/queue/{item_id}/image")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, b"legacy")
+        self.assertEqual(resp.mimetype, "image/png")
+        fs_mock.get.assert_called_once_with(file_id)
+        open_mock.assert_not_called()
+
+    def test_get_image_returns_404_when_filesystem_path_missing(self):
+        item_id = ObjectId()
+        item = {"_id": item_id, "imagePath": "gone.jpg", "fileId": None}
+        with patch("controllers.ocr_queue_controller.get_ocr_queue_item", return_value=item), \
+             patch("controllers.ocr_queue_controller.image_store.open_path",
+                   side_effect=FileNotFoundError("gone.jpg")):
+            resp = self.client.get(f"/api/ocr/queue/{item_id}/image")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_get_image_returns_404_when_neither_path_nor_fileid(self):
+        item_id = ObjectId()
+        item = {"_id": item_id, "imagePath": None, "fileId": None}
+        with patch("controllers.ocr_queue_controller.get_ocr_queue_item", return_value=item):
+            resp = self.client.get(f"/api/ocr/queue/{item_id}/image")
+        self.assertEqual(resp.status_code, 404)
 
 
 class JobStageTests(_OcrQueueControllerTestBase):

--- a/backend/tests/unit/test_ocr_queue_controller.py
+++ b/backend/tests/unit/test_ocr_queue_controller.py
@@ -313,10 +313,15 @@ class GetItemImageTests(_OcrQueueControllerTestBase):
 
         class _FakeGrid:
             content_type = "image/png"
+
+            def __init__(self):
+                self._buf = io.BytesIO(b"legacy")
+
             def read(self, n=-1):
-                return b"legacy"
+                return self._buf.read(n)
+
             def close(self):
-                pass
+                self._buf.close()
 
         with patch("controllers.ocr_queue_controller.get_ocr_queue_item", return_value=item), \
              patch("controllers.ocr_queue_controller.image_store.open_path") as open_mock, \

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -43,6 +43,11 @@ services:
       TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID}
       TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}
       TWILIO_PHONE_NUMBER: ${TWILIO_PHONE_NUMBER}
+      FEATURE_OCR_AUTO_EXTRACT: ${FEATURE_OCR_AUTO_EXTRACT:-false}
+      IMAGE_STORE_DIR: /var/lib/avenu/images
+      IMAGE_RETENTION_HOURS: ${IMAGE_RETENTION_HOURS:-24}
+    volumes:
+      - mail-images:/var/lib/avenu/images
     ports:
       - 18000:8000
     healthcheck:
@@ -96,6 +101,7 @@ services:
       BACKEND_API_URL: http://backend:8000
       SCHEDULER_INTERNAL_TOKEN: ${SCHEDULER_INTERNAL_TOKEN}
       SCHEDULER_CRON: ${SCHEDULER_CRON:-0 8 * * 1}
+      IMAGE_PRUNE_CRON: ${IMAGE_PRUNE_CRON:-0 3 * * *}
       SCHEDULER_TIMEZONE: ${SCHEDULER_TIMEZONE:-UTC}
       SCHEDULER_TICK_SECONDS: ${SCHEDULER_TICK_SECONDS:-20}
     restart: unless-stopped
@@ -131,3 +137,9 @@ volumes:
       device: ${PROMETHEUS_CONFIG_DIR:-/mnt/Main/other/PrometheusMailEtc/}
   grafana-data:
     driver: local
+  mail-images:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${MAIL_IMAGES_DIR:-/mnt/Main/other/AvenuMailImages/}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID}
       TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}
       TWILIO_PHONE_NUMBER: ${TWILIO_PHONE_NUMBER}
+      FEATURE_OCR_AUTO_EXTRACT: ${FEATURE_OCR_AUTO_EXTRACT:-false}
+      IMAGE_STORE_DIR: /var/lib/avenu/images
+      IMAGE_RETENTION_HOURS: ${IMAGE_RETENTION_HOURS:-24}
+    volumes:
+      - mail-images:/var/lib/avenu/images
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health', timeout=5)"]
       interval: 10s
@@ -59,6 +64,7 @@ services:
       BACKEND_API_URL: http://backend:8000
       SCHEDULER_INTERNAL_TOKEN: ${SCHEDULER_INTERNAL_TOKEN}
       SCHEDULER_CRON: ${SCHEDULER_CRON:-0 8 * * 1}
+      IMAGE_PRUNE_CRON: ${IMAGE_PRUNE_CRON:-0 3 * * *}
       SCHEDULER_TIMEZONE: ${SCHEDULER_TIMEZONE:-UTC}
       SCHEDULER_TICK_SECONDS: ${SCHEDULER_TICK_SECONDS:-20}
     restart: unless-stopped
@@ -67,6 +73,9 @@ services:
         condition: service_healthy
     networks:
       - avenu-internal
+
+volumes:
+  mail-images:
 
 networks:
   avenu-internal:

--- a/docs/01-architecture/diagrams/data-model.mmd
+++ b/docs/01-architecture/diagrams/data-model.mmd
@@ -94,6 +94,8 @@ erDiagram
         string rawText "optional"
         string error "optional"
         ObjectId mailboxId FK "optional"
+        ObjectId fileId FK "optional; legacy GridFS reference, nullable for new uploads"
+        string imagePath "optional; relative path under IMAGE_STORE_DIR volume"
         datetime confirmedAt "optional"
         datetime createdAt
         datetime updatedAt

--- a/docs/02-plans/plan-mail-photo-staging-volume.md
+++ b/docs/02-plans/plan-mail-photo-staging-volume.md
@@ -1,0 +1,144 @@
+# Open Questions
+- None.
+
+# Locked Decisions
+- Image bytes live on a host bind-mounted Docker volume at `IMAGE_STORE_DIR` (default `/var/lib/avenu/images`). Filename pattern: `<ObjectId>.<ext>`, derived from upload content-type.
+- OCR auto-extract is gated behind a new `FEATURE_OCR_AUTO_EXTRACT` env flag (default off). When off, uploads land as `pending` queue items with empty `receiverName` / `senderInfo`, and the existing review UI lets the admin fill them in by hand. When on, the existing background OCR thread runs unchanged.
+- New `OCR_QUEUE_ITEM` documents store an optional `imagePath: str` (relative to `IMAGE_STORE_DIR`). Existing `fileId` (GridFS ObjectId) field stays for backwards-compat reads.
+- Image read endpoint resolves in order: `imagePath` → filesystem; fallback `fileId` → GridFS. No data migration is performed; old uploads keep working untouched.
+- Retention: hard 24h. A nightly cleanup deletes any image file with mtime older than 24h AND any `OCR_QUEUE_ITEM` doc with `createdAt` older than 24h regardless of status. No exceptions for "forgotten" pending items — that's the contract.
+- Cleanup is triggered by the existing `scheduler` container hitting a new internal admin endpoint `POST /api/internal/jobs/prune-staged-images` authenticated with `SCHEDULER_INTERNAL_TOKEN`. Cron expression configurable via new `IMAGE_PRUNE_CRON` (default `0 3 * * *` local time).
+- Scheduler now supports two independent cron schedules: existing weekly summary (`SCHEDULER_CRON`) and new image prune (`IMAGE_PRUNE_CRON`). Both share the tick loop; loop minute-key dedupe is per-job.
+- Existing OCR queue UI label/route remains; no rename in this iteration. Admin enables the workflow with `FEATURE_ADMIN_OCR=true` + `FEATURE_OCR_QUEUE_V2=true` (already exists). `FEATURE_OCR_AUTO_EXTRACT` is the only new flag the operator needs to know about.
+
+# Task Checklist
+## Phase 1 — Backend storage abstraction + flag
+- ☑ Add `IMAGE_STORE_DIR` and `FEATURE_OCR_AUTO_EXTRACT` env handling in `backend/config.py`; expose `get_feature_flags()['ocrAutoExtract']` for parity with other flags.
+- ☑ New `backend/services/image_store.py`: `save_bytes(data, content_type) -> str` (returns relative path), `open_path(rel_path) -> (stream, content_type)`, `delete_path(rel_path) -> bool`, `prune_older_than(seconds) -> int`. No Mongo; pure filesystem.
+- ☑ Extend `OCR_QUEUE_ITEM` schema doc + `repositories/ocr_queue_repository.create_ocr_queue_items` to accept and persist `image_paths` alongside (or instead of) `file_ids`.
+- ☑ Backend unit tests for `image_store` (round-trip, delete, prune-by-mtime) using `tmp_path`.
+
+## Phase 2 — Wire upload + read + skip-OCR path
+- ☑ `controllers/ocr_queue_controller.create_job`: write each upload via `image_store.save_bytes` (not `fs.put`), pass `image_paths` to `create_ocr_queue_items`. Keep `fileId` writes for any legacy code path that already relies on GridFS (none today besides this controller — drop the GridFS write).
+- ☑ `controllers/ocr_queue_controller.create_job`: skip the background OCR thread when `FEATURE_OCR_AUTO_EXTRACT` is false; mark items `pending` with no `rawText`.
+- ☑ `controllers/ocr_queue_controller.get_item_image`: prefer `imagePath` via `image_store.open_path`; fall back to `fs.get(fileId)` when `imagePath` absent (legacy items).
+- ☑ `_serialize_item` exposes `imagePath` (string) so the frontend has a stable shape; existing `fileId` field remains.
+- ☑ Backend unit tests covering: skip-OCR upload path leaves items `pending`; image read prefers filesystem; fallback to GridFS works.
+
+## Phase 3 — Nightly prune endpoint + scheduler
+- ☑ New `controllers/internal_jobs_controller` route `POST /api/internal/jobs/prune-staged-images`, internal-token guarded. Body optional `{"olderThanHours": int}` with default `IMAGE_RETENTION_HOURS=24`. Returns `{filesDeleted, itemsDeleted, errors}`.
+- ☑ Service `services/image_pruner.py`: orchestrates filesystem prune + queue-item deletion in one transactional-best-effort sweep (per-doc tolerant of partial failures, returns counts).
+- ☑ `scheduler/config.py` + `scheduler/main.py`: add second cron (`IMAGE_PRUNE_CRON`, default `0 3 * * *`); each tick checks both schedules independently; `last_processed_minute` becomes a per-job dict.
+- ☑ `scheduler/client.py`: new `trigger_image_prune(token)` method analogous to `trigger_weekly_summary`.
+- ☑ Backend unit test for prune service (creates fake old + new files, verifies only old removed; verifies queue items pruned by `createdAt`).
+- ☑ Scheduler unit test for two-job tick dedupe (same minute fires once per job, different cron windows fire independently).
+
+## Phase 4 — Compose volume + docs
+- ☑ `docker-compose.yml`: add `mail-images` named volume bound to host dir; mount at `/var/lib/avenu/images`; pass `IMAGE_STORE_DIR`, `IMAGE_RETENTION_HOURS`, `FEATURE_OCR_AUTO_EXTRACT` env vars to backend; pass `IMAGE_PRUNE_CRON` to scheduler.
+- ☑ `docker-compose-prod.yml`: same, with `device: ${MAIL_IMAGES_DIR:-/mnt/Main/other/AvenuMailImages/}` to match the Prometheus pattern.
+- ☑ `docs/01-architecture/diagrams/data-model.mmd`: add `imagePath` field on `OCR_QUEUE_ITEM`.
+
+---
+
+## Phase 1: Backend storage abstraction + flag
+Affected files and changes
+- `backend/config.py`
+  - `IMAGE_STORE_DIR = os.getenv("IMAGE_STORE_DIR", "/var/lib/avenu/images")` (created on startup if missing).
+  - `IMAGE_RETENTION_HOURS = _env_positive_int("IMAGE_RETENTION_HOURS", 24)`.
+  - `FEATURE_OCR_AUTO_EXTRACT = _env_bool("FEATURE_OCR_AUTO_EXTRACT", False)`.
+  - Add `"ocrAutoExtract": FEATURE_OCR_AUTO_EXTRACT and FEATURE_ADMIN_OCR` to `get_feature_flags()`.
+- `backend/services/image_store.py` (new)
+  - Pure-stdlib module. No Flask, no Mongo. Uses `pathlib`, `secrets.token_hex`, `mimetypes`.
+  - `save_bytes(data: bytes, content_type: str) -> str`: choose extension from content-type (`image/png` → `.png`, etc; default `.bin`); write to `IMAGE_STORE_DIR/<token_hex(12)>.<ext>`; return relative path string.
+  - `open_path(rel_path: str) -> tuple[BinaryIO, str]`: validates the resolved path is inside `IMAGE_STORE_DIR` (no traversal); returns open binary stream and inferred content type.
+  - `delete_path(rel_path: str) -> bool`: best-effort unlink; returns success.
+  - `prune_older_than(seconds: int) -> int`: walks `IMAGE_STORE_DIR`, unlinks files where `mtime < now - seconds`; returns count.
+- `backend/repositories/ocr_queue_repository.py`
+  - `create_ocr_queue_items(job_id, count, *, image_paths: list[str] | None = None, file_ids: list[ObjectId] | None = None)`: persist `imagePath` and/or `fileId` per item.
+
+Implementation notes
+- Path validation in `open_path`: `Path(IMAGE_STORE_DIR).resolve() in resolved.parents` — refuse anything else with `APIError(404)`.
+- `save_bytes` returns a *relative* path so storage dir can move without DB rewrites.
+- No write fan-out to GridFS. New code path is one place: `save_bytes`.
+
+Unit tests (phase-local)
+- `backend/tests/unit/test_image_store.py`
+  - `test_save_then_open_round_trips_bytes_and_content_type`
+  - `test_save_uses_content_type_extension`
+  - `test_open_path_rejects_traversal`
+  - `test_delete_path_returns_false_when_missing`
+  - `test_prune_older_than_only_deletes_stale_files`
+
+---
+
+## Phase 2: Wire upload + read + skip-OCR path
+Affected files and changes
+- `backend/controllers/ocr_queue_controller.py`
+  - Replace the GridFS write loop with `image_paths = [save_bytes(data, ct) for data, ct in image_payloads]`.
+  - Pass `image_paths=image_paths` to `create_ocr_queue_items`.
+  - Skip background thread launch entirely when `not FEATURE_OCR_AUTO_EXTRACT`. Items are left `pending`.
+  - `get_item_image`: if `item.get("imagePath")`, stream via `image_store.open_path`; else fall back to existing `fs.get(item["fileId"])`. Raise `404` if neither present.
+  - `_serialize_item`: include `imagePath` field.
+- `backend/config.py`
+  - Surface `IMAGE_RETENTION_HOURS` (used in Phase 3 but cheaper to add here).
+
+Implementation notes
+- Keep `from config import fs` — it's only needed by the GridFS fallback branch and by any legacy admin page that surfaces ad-hoc uploads.
+- `_process_ocr_job` is unchanged, just no longer started in skip-OCR mode.
+
+Unit tests (phase-local)
+- `backend/tests/unit/test_ocr_queue_controller.py`
+  - `test_create_job_skips_ocr_thread_when_feature_off` (assert no thread started; items remain `pending`).
+  - `test_create_job_writes_image_paths_to_items`
+  - `test_get_item_image_prefers_filesystem_path`
+  - `test_get_item_image_falls_back_to_gridfs_when_no_path`
+
+---
+
+## Phase 3: Nightly prune endpoint + scheduler
+Affected files and changes
+- `backend/services/image_pruner.py` (new)
+  - `prune_staged_images(*, older_than_hours: int) -> dict[str, int]`:
+    1. Compute `cutoff = utcnow() - timedelta(hours=older_than_hours)`.
+    2. Query `ocr_queue_items_collection.find({"createdAt": {"$lt": cutoff}}, {"imagePath": 1, "fileId": 1})`.
+    3. For each, attempt `image_store.delete_path(imagePath)` if present; else `fs.delete(fileId)` if present.
+    4. `delete_many({"createdAt": {"$lt": cutoff}})` for the items.
+    5. Final sweep `image_store.prune_older_than(older_than_hours * 3600)` to catch orphans whose row was already deleted.
+    6. Return `{filesDeleted, itemsDeleted, orphanFilesDeleted, errors}`.
+- `backend/controllers/internal_jobs_controller.py`
+  - New route `POST /api/internal/jobs/prune-staged-images` mirroring the existing weekly-summary pattern: validates internal token, parses optional `olderThanHours` (defaults to `IMAGE_RETENTION_HOURS`), calls `prune_staged_images`, returns counts.
+- `scheduler/config.py`
+  - Parse second cron `IMAGE_PRUNE_CRON` (default `"0 3 * * *"`). Keep existing `SCHEDULER_CRON` untouched.
+- `scheduler/main.py`
+  - `last_processed_minute` becomes `dict[str, str]` keyed by job name (`"weekly_summary"`, `"image_prune"`).
+  - Each tick: for each `(job_name, schedule, action)` triple, dedupe + run.
+  - `action` for image prune: `client.trigger_image_prune(scheduler_token=...)`.
+- `scheduler/client.py`
+  - New `trigger_image_prune(scheduler_token: str) -> dict`: `POST /api/internal/jobs/prune-staged-images` with the standard internal-token header. No body; backend uses default retention.
+
+Implementation notes
+- Single-tick concurrency: the existing tick loop is single-threaded. Two jobs at the same minute boundary will both run sequentially. Acceptable.
+- The orphan sweep at the end of `prune_staged_images` makes the contract idempotent: even if a row was deleted by hand and the file was orphaned, it'll get cleaned within 24h.
+
+Unit tests (phase-local)
+- `backend/tests/unit/test_image_pruner.py`
+  - `test_prune_deletes_old_files_and_items`
+  - `test_prune_keeps_fresh_items_and_files`
+  - `test_prune_handles_missing_files_gracefully`
+  - `test_prune_orphan_sweep_catches_files_without_rows`
+- `scheduler/tests/test_main.py` (new or extended)
+  - `test_two_jobs_dedupe_independently_in_same_tick`
+  - `test_image_prune_only_fires_at_03_00_local`
+
+---
+
+## Phase 4: Compose volume + docs
+Affected files and changes
+- `docker-compose.yml`
+  - Backend service: add `volumes: - mail-images:/var/lib/avenu/images`; add `IMAGE_STORE_DIR`, `IMAGE_RETENTION_HOURS`, `FEATURE_OCR_AUTO_EXTRACT` to `environment`.
+  - Scheduler service: add `IMAGE_PRUNE_CRON` to `environment`.
+  - Top-level `volumes: { mail-images: { driver: local } }` (default named volume for dev).
+- `docker-compose-prod.yml`
+  - Same as above, plus `mail-images` configured with `driver_opts: { type: none, o: bind, device: ${MAIL_IMAGES_DIR:-/mnt/Main/other/AvenuMailImages/} }` to match the Prometheus pattern.
+- `docs/01-architecture/diagrams/data-model.mmd`
+  - Add `string imagePath "optional, relative to IMAGE_STORE_DIR"` to `OCR_QUEUE_ITEM`.

--- a/frontend/src/lib/api/routes/featureFlags.ts
+++ b/frontend/src/lib/api/routes/featureFlags.ts
@@ -5,6 +5,11 @@ export interface ApiFeatureFlags {
   adminOcr: boolean;
   ocrQueueV2: boolean;
   ocrShadowLaunch: boolean;
+  /**
+   * When true, uploaded queue images are OCR'd automatically; when false they land as
+   * `pending` for manual review. Implies `adminOcr`.
+   */
+  ocrAutoExtract: boolean;
 }
 
 export function fetchFeatureFlags(): Promise<ApiFeatureFlags> {

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -15,6 +15,7 @@ export interface FeatureFlags {
   adminOcr: boolean;
   ocrQueueV2: boolean;
   ocrShadowLaunch: boolean;
+  ocrAutoExtract: boolean;
 }
 
 interface AppState {
@@ -41,6 +42,7 @@ export const useAppStore = create<AppState>((set) => ({
     adminOcr: false,
     ocrQueueV2: false,
     ocrShadowLaunch: false,
+    ocrAutoExtract: false,
   },
   isHydratingFeatureFlags: true,
   setSessionUser: (user) => set({ sessionUser: user }),

--- a/scheduler/client.py
+++ b/scheduler/client.py
@@ -38,14 +38,37 @@ class BackendClient:
                 "Idempotency-Key": idempotency_key,
             },
         )
-        try:
-            with urllib.request.urlopen(request, timeout=10) as response:
-                raw = response.read().decode("utf-8")
-                if not raw:
-                    return {}
-                return json.loads(raw)
-        except urllib.error.HTTPError as exc:
-            detail = exc.read().decode("utf-8", errors="replace")
-            raise BackendClientError(f"backend returned status={exc.code} body={detail}") from exc
-        except urllib.error.URLError as exc:
-            raise BackendClientError(str(exc)) from exc
+        return _send(request)
+
+    def trigger_image_prune(
+        self,
+        *,
+        scheduler_token: str,
+        idempotency_key: str,
+    ) -> dict:
+        payload = json.dumps({}).encode("utf-8")
+        request = urllib.request.Request(
+            url=f"{self._base_url}/api/internal/jobs/image-prune",
+            method="POST",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "X-Scheduler-Token": scheduler_token,
+                "Idempotency-Key": idempotency_key,
+            },
+        )
+        return _send(request)
+
+
+def _send(request: urllib.request.Request) -> dict:
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+            if not raw:
+                return {}
+            return json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise BackendClientError(f"backend returned status={exc.code} body={detail}") from exc
+    except urllib.error.URLError as exc:
+        raise BackendClientError(str(exc)) from exc

--- a/scheduler/config.py
+++ b/scheduler/config.py
@@ -54,6 +54,8 @@ class SchedulerConfig:
     scheduler_token: str
     cron_expression: str
     schedule: CronSchedule
+    image_prune_cron_expression: str
+    image_prune_schedule: CronSchedule
     timezone: ZoneInfo
     tick_seconds: int
 
@@ -69,6 +71,11 @@ def load_config() -> SchedulerConfig:
         raise RuntimeError("SCHEDULER_CRON is required")
     schedule = parse_cron_expression(cron_expression)
 
+    image_prune_cron_expression = os.getenv("IMAGE_PRUNE_CRON", "0 3 * * *").strip()
+    if not image_prune_cron_expression:
+        raise RuntimeError("IMAGE_PRUNE_CRON is required")
+    image_prune_schedule = parse_cron_expression(image_prune_cron_expression)
+
     timezone_name = os.getenv("SCHEDULER_TIMEZONE", "UTC").strip() or "UTC"
     timezone = ZoneInfo(timezone_name)
 
@@ -81,6 +88,8 @@ def load_config() -> SchedulerConfig:
         scheduler_token=scheduler_token,
         cron_expression=cron_expression,
         schedule=schedule,
+        image_prune_cron_expression=image_prune_cron_expression,
+        image_prune_schedule=image_prune_schedule,
         timezone=timezone,
         tick_seconds=tick_seconds,
     )

--- a/scheduler/main.py
+++ b/scheduler/main.py
@@ -8,20 +8,26 @@ from client import BackendClient, BackendClientError
 from config import load_config
 
 
+logger = logging.getLogger("scheduler")
+
+
 def main() -> int:
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    logger = logging.getLogger("scheduler")
     config = load_config()
     client = BackendClient(config.backend_api_url)
-    last_processed_minute: str | None = None
+    last_fired: dict[str, str] = {}
 
     logger.info(
-        "scheduler_started backend=%s cron=%s timezone=%s tick_seconds=%d",
+        (
+            "scheduler_started backend=%s weekly_cron=%s image_prune_cron=%s timezone=%s "
+            "tick_seconds=%d"
+        ),
         config.backend_api_url,
         config.cron_expression,
+        config.image_prune_cron_expression,
         config.timezone.key,
         config.tick_seconds,
     )
@@ -29,38 +35,71 @@ def main() -> int:
         now_utc = datetime.now(tz=timezone.utc)
         local_now = now_utc.astimezone(config.timezone).replace(second=0, microsecond=0)
         minute_key = local_now.strftime("%Y-%m-%dT%H:%M")
-        if minute_key != last_processed_minute and config.schedule.matches(local_now):
-            week_start, week_end = compute_previous_week_range(now_utc)
-            idempotency_key = f"weekly-summary:{week_start.isoformat()}"
-            try:
-                result = client.trigger_weekly_summary(
-                    scheduler_token=config.scheduler_token,
-                    week_start=week_start,
-                    week_end=week_end,
-                    idempotency_key=idempotency_key,
-                )
-                logger.info(
-                    (
-                        "weekly_summary_trigger_success weekStart=%s weekEnd=%s processed=%s sent=%s "
-                        "skipped=%s failed=%s errors=%s"
-                    ),
-                    week_start.isoformat(),
-                    week_end.isoformat(),
-                    result.get("processed"),
-                    result.get("sent"),
-                    result.get("skipped"),
-                    result.get("failed"),
-                    result.get("errors"),
-                )
-            except BackendClientError as exc:
-                logger.exception(
-                    "weekly_summary_trigger_failed weekStart=%s weekEnd=%s detail=%s",
-                    week_start.isoformat(),
-                    week_end.isoformat(),
-                    str(exc),
-                )
-            last_processed_minute = minute_key
+
+        if last_fired.get("weekly") != minute_key and config.schedule.matches(local_now):
+            _run_weekly_summary(client, config.scheduler_token, now_utc)
+            last_fired["weekly"] = minute_key
+
+        if last_fired.get("image_prune") != minute_key and config.image_prune_schedule.matches(local_now):
+            _run_image_prune(client, config.scheduler_token, local_now)
+            last_fired["image_prune"] = minute_key
+
         time.sleep(config.tick_seconds)
+
+
+def _run_weekly_summary(client: BackendClient, token: str, now_utc: datetime) -> None:
+    week_start, week_end = compute_previous_week_range(now_utc)
+    idempotency_key = f"weekly-summary:{week_start.isoformat()}"
+    try:
+        result = client.trigger_weekly_summary(
+            scheduler_token=token,
+            week_start=week_start,
+            week_end=week_end,
+            idempotency_key=idempotency_key,
+        )
+        logger.info(
+            (
+                "weekly_summary_trigger_success weekStart=%s weekEnd=%s processed=%s sent=%s "
+                "skipped=%s failed=%s errors=%s"
+            ),
+            week_start.isoformat(),
+            week_end.isoformat(),
+            result.get("processed"),
+            result.get("sent"),
+            result.get("skipped"),
+            result.get("failed"),
+            result.get("errors"),
+        )
+    except BackendClientError as exc:
+        logger.exception(
+            "weekly_summary_trigger_failed weekStart=%s weekEnd=%s detail=%s",
+            week_start.isoformat(),
+            week_end.isoformat(),
+            str(exc),
+        )
+
+
+def _run_image_prune(client: BackendClient, token: str, local_now: datetime) -> None:
+    # Keying on local date (not minute) keeps a single retry on backend failure
+    # from triggering duplicate prunes on the same day.
+    idempotency_key = f"image-prune:{local_now.date().isoformat()}"
+    try:
+        result = client.trigger_image_prune(
+            scheduler_token=token,
+            idempotency_key=idempotency_key,
+        )
+        logger.info(
+            (
+                "image_prune_trigger_success rowsScanned=%s filesDeleted=%s "
+                "rowsMarkedDeleted=%s orphanFilesDeleted=%s"
+            ),
+            result.get("rowsScanned"),
+            result.get("filesDeleted"),
+            result.get("rowsMarkedDeleted"),
+            result.get("orphanFilesDeleted"),
+        )
+    except BackendClientError as exc:
+        logger.exception("image_prune_trigger_failed detail=%s", str(exc))
 
 
 def compute_previous_week_range(now: datetime) -> tuple[date, date]:

--- a/scheduler/tests/test_backend_client.py
+++ b/scheduler/tests/test_backend_client.py
@@ -113,6 +113,56 @@ class BackendClientTests(unittest.TestCase):
             )
         self.assertEqual(result["skipped"], 1)
 
+    def test_client_posts_image_prune_with_empty_body(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=0):
+            captured["url"] = request.full_url
+            captured["method"] = request.get_method()
+            captured["idempotency_key"] = request.get_header("Idempotency-key")
+            captured["scheduler_token"] = request.get_header("X-scheduler-token")
+            captured["payload"] = json.loads(request.data.decode("utf-8"))
+            return _FakeResponse(
+                status=200,
+                body={
+                    "rowsScanned": 2,
+                    "filesDeleted": 2,
+                    "rowsMarkedDeleted": 2,
+                    "orphanFilesDeleted": 0,
+                },
+            )
+
+        client = BackendClient("http://backend:8000")
+        with patch("client.urllib.request.urlopen", side_effect=fake_urlopen):
+            result = client.trigger_image_prune(
+                scheduler_token="scheduler-secret",
+                idempotency_key="image-prune:2026-04-21",
+            )
+
+        self.assertEqual(captured["url"], "http://backend:8000/api/internal/jobs/image-prune")
+        self.assertEqual(captured["method"], "POST")
+        self.assertEqual(captured["payload"], {})
+        self.assertEqual(captured["idempotency_key"], "image-prune:2026-04-21")
+        self.assertEqual(captured["scheduler_token"], "scheduler-secret")
+        self.assertEqual(result["filesDeleted"], 2)
+
+    def test_image_prune_surfaces_http_errors(self):
+        client = BackendClient("http://backend:8000")
+        error = HTTPError(
+            url="http://backend:8000/api/internal/jobs/image-prune",
+            code=503,
+            msg="unavail",
+            hdrs=None,
+            fp=None,
+        )
+        error.read = lambda: b'{"error":"scheduler token is not configured"}'
+        with patch("client.urllib.request.urlopen", side_effect=error):
+            with self.assertRaises(BackendClientError):
+                client.trigger_image_prune(
+                    scheduler_token="scheduler-secret",
+                    idempotency_key="image-prune:2026-04-21",
+                )
+
     def test_client_handles_non_2xx_with_structured_error(self):
         client = BackendClient("http://backend:8000")
         error = HTTPError(


### PR DESCRIPTION
## Summary
Move OCR queue mail photos out of MongoDB GridFS onto a bind-mounted filesystem volume, and add a scheduler-driven nightly prune so disk usage stays bounded. Adds the `FEATURE_OCR_AUTO_EXTRACT` flag and a CI guardrail against hung backend tests.
## Why
GridFS was an awkward fit for OCR images: every read paged blob chunks through Mongo, backups bloated, and there was no retention story. Storing the bytes on a bind-mount keeps the DB lean, makes images directly accessible to whichever container needs them, and lets us prune by age on a cron.
## What's in this PR
### Storage
- New `backend/services/image_store.py` — atomic `save_bytes` / `delete_path` / `prune_older_than` over a directory rooted at `IMAGE_STORE_DIR`.
- `backend/controllers/ocr_queue_controller.py` writes uploaded mail photos via `image_store` and persists the resulting `imagePath` on the OCR queue item (replacing the old `fileId` GridFS reference). `get_item_image` prefers `imagePath` and only falls back to GridFS for legacy rows.
- `OCR_QUEUE_ITEM` data-model diagram updated.
### Retention
- New `backend/services/image_pruner.py` with two-phase cleanup:
  1. Row-driven: query Mongo for items past `IMAGE_RETENTION_HOURS`, unlink the file, soft-delete the row.
  2. Orphan sweep: walk `IMAGE_STORE_DIR` and unlink anything older than retention without a backing row.
- New internal endpoint `POST /api/internal/jobs/image-prune` (auth: `SCHEDULER_INTERNAL_TOKEN`) wired in `internal_jobs_controller.py`.
- Scheduler tick loop runs `_run_image_prune` on the `IMAGE_PRUNE_CRON` schedule (default `0 3 * * *`); `scheduler/client.py` POSTs to the new internal endpoint with the shared token.
### Feature flag + config
- `FEATURE_OCR_AUTO_EXTRACT` toggle exposed through `get_feature_flags()` and surfaced to the frontend (`featureFlags.ts`, `store.ts`). When off, items stay `pending` and admins fill metadata manually during review.
- `IMAGE_STORE_DIR`, `IMAGE_RETENTION_HOURS`, `IMAGE_PRUNE_CRON` added to `backend/config.py`, `.env.sample`, and both `docker-compose.yml` / `docker-compose-prod.yml` (with a `mail-images` volume bind).
### CI
- Added `timeout-minutes: 15` to the backend `build` job. Yesterday's run hung for 1h 28m before being cancelled by the runner — this fails fast on stuck tests instead of burning the budget.
### Tests
- `tests/unit/test_image_store.py` — round-trip, retention, orphan paths.
- `tests/unit/test_image_pruner.py` — both prune phases plus mocked Mongo.
- `tests/unit/test_ocr_queue_controller.py` — extended for filesystem path; legacy GridFS path still covered.
- `scheduler/tests/test_backend_client.py` — image-prune POST with token.
### Docs
- `docs/02-plans/plan-mail-photo-staging-volume.md` documents the design.
## Migration notes
- Existing GridFS-backed rows keep working: `get_item_image` falls back to `fileId` when `imagePath` is absent. New uploads always use `imagePath`. No backfill required for this PR; we can drop the GridFS branch in a follow-up once the legacy queue drains.
- Set `IMAGE_STORE_DIR` and create the bind-mount before deploy. `docker-compose.yml` already declares the `mail-images` volume.
## Test plan
- [ ] `cd backend && pytest tests/unit/test_image_store.py tests/unit/test_image_pruner.py tests/unit/test_ocr_queue_controller.py`
- [ ] `cd scheduler && pytest tests/test_backend_client.py`
- [ ] Local smoke: `docker compose up`, upload a photo through the OCR queue, confirm the file lands in `IMAGE_STORE_DIR` and the queue item has `imagePath` set.
- [ ] Manually invoke the prune endpoint with the scheduler token and confirm both row-driven and orphan deletes occur.
- [ ] CI green; backend build completes well under the new 15-minute cap.