### PR TITLE
Remove E.164 validation for optional phone fields

### DIFF
--- a/backend/controllers/session_controller.py
+++ b/backend/controllers/session_controller.py
@@ -158,6 +158,7 @@ def session_me():
                 "emailNotifications": normalized["emailNotifications"],
                 "smsNotifications": normalized["smsNotifications"],
                 "hasPhone": normalized["hasPhone"],
+                "hasSmsPhone": normalized["hasSmsPhone"],
             }
         ),
         200,

--- a/backend/services/member_service.py
+++ b/backend/services/member_service.py
@@ -45,4 +45,5 @@ def update_member_notification_preferences(
         "emailNotifications": normalized["emailNotifications"],
         "smsNotifications": normalized["smsNotifications"],
         "hasPhone": normalized["hasPhone"],
+        "hasSmsPhone": normalized["hasSmsPhone"],
     }

--- a/backend/services/notifications/channels/sms_channel.py
+++ b/backend/services/notifications/channels/sms_channel.py
@@ -4,6 +4,7 @@ from datetime import date, datetime
 from typing import Union
 
 from services.notifications.providers.sms_provider import SMSProvider
+from validators import is_e164_phone
 from services.notifications.types import ChannelResult, SpecialCaseNotificationPayload, WeeklySummaryData, WeeklySummaryNotificationPayload
 
 
@@ -14,9 +15,12 @@ class SMSChannel:
         self.provider = provider
 
     def send(self, payload: WeeklySummaryNotificationPayload | SpecialCaseNotificationPayload) -> ChannelResult:
-        phone = self._resolve_phone(payload)
-        if not phone:
+        raw_phone = payload["user"].get("phone")
+        if not isinstance(raw_phone, str) or not raw_phone.strip():
             return {"channel": self.channel, "status": "skipped", "error": "missing phone"}
+        phone = raw_phone.strip()
+        if not is_e164_phone(phone):
+            return {"channel": self.channel, "status": "skipped", "error": "invalid phone for SMS"}
 
         if "summary" in payload:
             body = self._build_weekly_summary_body(payload)
@@ -36,12 +40,6 @@ class SMSChannel:
                 "status": "failed",
                 "error": str(exc),
             }
-
-    def _resolve_phone(self, payload: WeeklySummaryNotificationPayload | SpecialCaseNotificationPayload) -> str:
-        raw_phone = payload["user"].get("phone")
-        if not isinstance(raw_phone, str):
-            return ""
-        return raw_phone.strip()
 
     def _build_weekly_summary_body(self, payload: WeeklySummaryNotificationPayload) -> str:
         summary = payload["summary"]

--- a/backend/services/user_preferences.py
+++ b/backend/services/user_preferences.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from errors import APIError
+from validators import is_e164_phone
 
 UNSET = object()
 _EMAIL_PREF = "email"
@@ -71,14 +72,21 @@ def normalize_effective_notification_state(
             effective_prefs.discard(_SMS_PREF)
 
     has_phone = effective_phone is not None
-    if not has_phone:
+    has_sms_phone = bool(effective_phone and is_e164_phone(effective_phone))
+    if not has_sms_phone:
         if explicit_sms_enable:
-            raise APIError(400, "SMS notifications require a valid phone number")
+            if not has_phone:
+                raise APIError(400, "SMS notifications require a valid phone number")
+            raise APIError(
+                400,
+                "SMS notifications require a phone number in E.164 format (for example +15551234567)",
+            )
         effective_prefs.discard(_SMS_PREF)
 
     return {
         "phone": effective_phone,
         "hasPhone": has_phone,
+        "hasSmsPhone": has_sms_phone,
         "notifPrefs": _to_ordered_storage_prefs(effective_prefs),
         "emailNotifications": _EMAIL_PREF in effective_prefs,
         "smsNotifications": _SMS_PREF in effective_prefs,

--- a/backend/tests/unit/test_admin_session_auth.py
+++ b/backend/tests/unit/test_admin_session_auth.py
@@ -454,6 +454,7 @@ class AdminSessionAuthTests(unittest.TestCase):
                 "emailNotifications": True,
                 "smsNotifications": False,
                 "hasPhone": True,
+                "hasSmsPhone": True,
             },
         )
 
@@ -493,7 +494,13 @@ class AdminSessionAuthTests(unittest.TestCase):
         with self.client.session_transaction() as sess:
             sess["user_id"] = user_id
 
-        expected = {"id": user_id, "emailNotifications": True, "smsNotifications": False, "hasPhone": True}
+        expected = {
+            "id": user_id,
+            "emailNotifications": True,
+            "smsNotifications": False,
+            "hasPhone": True,
+            "hasSmsPhone": True,
+        }
         with patch("controllers.auth_guard.find_user", return_value=user_doc), patch(
             "controllers.member_controller.update_member_notification_preferences", return_value=expected
         ) as prefs_mock:
@@ -521,7 +528,13 @@ class AdminSessionAuthTests(unittest.TestCase):
         with self.client.session_transaction() as sess:
             sess["user_id"] = user_id
 
-        expected = {"id": user_id, "emailNotifications": True, "smsNotifications": True, "hasPhone": True}
+        expected = {
+            "id": user_id,
+            "emailNotifications": True,
+            "smsNotifications": True,
+            "hasPhone": True,
+            "hasSmsPhone": True,
+        }
         with patch("controllers.auth_guard.find_user", return_value=user_doc), patch(
             "controllers.member_controller.update_member_notification_preferences", return_value=expected
         ) as prefs_mock:

--- a/backend/tests/unit/test_member_service.py
+++ b/backend/tests/unit/test_member_service.py
@@ -31,6 +31,7 @@ class MemberServiceTests(unittest.TestCase):
                 "emailNotifications": True,
                 "smsNotifications": True,
                 "hasPhone": True,
+                "hasSmsPhone": True,
             },
         )
 
@@ -67,6 +68,47 @@ class MemberServiceTests(unittest.TestCase):
                 "emailNotifications": True,
                 "smsNotifications": False,
                 "hasPhone": False,
+                "hasSmsPhone": False,
+            },
+        )
+
+    def test_update_member_preferences_rejects_sms_when_phone_is_not_e164(self):
+        user = {"_id": ObjectId(), "notifPrefs": ["email"], "phone": "4125551234"}
+
+        with patch("services.member_service.update_notif_prefs") as update_mock:
+            with self.assertRaises(APIError) as ctx:
+                update_member_notification_preferences(
+                    user=user,
+                    sms_notifications=True,
+                )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(
+            ctx.exception.message,
+            "SMS notifications require a phone number in E.164 format (for example +15551234567)",
+        )
+        update_mock.assert_not_called()
+
+    def test_update_member_preferences_returns_has_sms_phone_false_for_naive_phone(self):
+        user_id = ObjectId()
+        user = {"_id": user_id, "notifPrefs": ["email"], "phone": "4125551234"}
+
+        with patch("services.member_service.update_notif_prefs") as update_mock:
+            response = update_member_notification_preferences(
+                user=user,
+                email_notifications=True,
+            )
+
+        update_mock.assert_called_once()
+        self.assertEqual(update_mock.call_args.args[1], ["email"])
+        self.assertEqual(
+            response,
+            {
+                "id": str(user_id),
+                "emailNotifications": True,
+                "smsNotifications": False,
+                "hasPhone": True,
+                "hasSmsPhone": False,
             },
         )
 

--- a/backend/tests/unit/test_sms_channel.py
+++ b/backend/tests/unit/test_sms_channel.py
@@ -61,6 +61,29 @@ class SMSChannelTests(unittest.TestCase):
         self.assertIn("missing phone", result["error"])
         self.assertEqual(provider.calls, [])
 
+    def test_send_returns_skipped_when_phone_is_not_e164(self):
+        provider = FakeSMSProvider()
+        channel = SMSChannel(provider)
+
+        result = channel.send(
+            {
+                "user": {
+                    "id": str(ObjectId()),
+                    "email": "member@example.com",
+                    "fullname": "Member User",
+                    "phone": "4125551234",
+                },
+                "triggeredBy": "admin",
+                "templateType": "mail-arrived",
+                "mailRequest": None,
+            }
+        )
+
+        self.assertEqual(result["channel"], "sms")
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("invalid phone for SMS", result["error"])
+        self.assertEqual(provider.calls, [])
+
     def test_send_special_case_formats_body_and_calls_provider(self):
         provider = FakeSMSProvider()
         channel = SMSChannel(provider)

--- a/backend/tests/unit/test_user_preferences.py
+++ b/backend/tests/unit/test_user_preferences.py
@@ -23,6 +23,7 @@ class UserPreferencesTests(unittest.TestCase):
         self.assertTrue(result["emailNotifications"])
         self.assertTrue(result["smsNotifications"])
         self.assertTrue(result["hasPhone"])
+        self.assertTrue(result["hasSmsPhone"])
 
     def test_normalize_effective_preferences_treats_whitespace_phone_as_missing(self):
         current_user = {
@@ -36,6 +37,7 @@ class UserPreferencesTests(unittest.TestCase):
         self.assertTrue(result["emailNotifications"])
         self.assertFalse(result["smsNotifications"])
         self.assertFalse(result["hasPhone"])
+        self.assertFalse(result["hasSmsPhone"])
 
     def test_normalize_effective_preferences_rejects_text_when_explicitly_enabled_without_phone(self):
         current_user = {
@@ -51,6 +53,37 @@ class UserPreferencesTests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertEqual(ctx.exception.message, "SMS notifications require a valid phone number")
+
+    def test_normalize_effective_preferences_strips_text_when_phone_is_not_e164(self):
+        current_user = {
+            "notifPrefs": ["email", "text"],
+            "phone": "4125551234",
+        }
+
+        result = normalize_effective_notification_state(current_user=current_user)
+
+        self.assertEqual(result["notifPrefs"], ["email"])
+        self.assertFalse(result["smsNotifications"])
+        self.assertTrue(result["hasPhone"])
+        self.assertFalse(result["hasSmsPhone"])
+
+    def test_normalize_effective_preferences_rejects_text_when_phone_is_naive_us_number(self):
+        current_user = {
+            "notifPrefs": [],
+            "phone": "4125551234",
+        }
+
+        with self.assertRaises(APIError) as ctx:
+            normalize_effective_notification_state(
+                current_user=current_user,
+                sms_notifications_patch=True,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(
+            ctx.exception.message,
+            "SMS notifications require a phone number in E.164 format (for example +15551234567)",
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -27,6 +27,43 @@ class UserServiceTests(unittest.TestCase):
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertEqual(ctx.exception.message, "SMS notifications require a valid phone number")
 
+    def test_update_user_rejects_text_pref_when_phone_is_not_e164(self):
+        user_id = ObjectId()
+
+        with patch(
+            "services.user_service.find_user",
+            return_value={"_id": user_id, "notifPrefs": [], "phone": "4125551234"},
+        ), patch(
+            "services.user_service.build_user_patch",
+            return_value={"notifPrefs": ["text"]},
+        ):
+            with self.assertRaises(APIError) as ctx:
+                update_user(user_id, payload={"notifPrefs": ["text"]})
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(
+            ctx.exception.message,
+            "SMS notifications require a phone number in E.164 format (for example +15551234567)",
+        )
+
+    def test_update_user_auto_removes_text_pref_when_phone_patched_to_non_e164(self):
+        user_id = ObjectId()
+        current = {"_id": user_id, "notifPrefs": ["email", "text"], "phone": "+15550001111"}
+        persisted = {"_id": user_id, "notifPrefs": ["email"], "phone": "4125551234"}
+
+        with patch("services.user_service.find_user", return_value=current), patch(
+            "services.user_service.build_user_patch",
+            return_value={"phone": "4125551234"},
+        ), patch(
+            "services.user_service.update_user_with_mailbox_sync",
+            return_value=persisted,
+        ) as update_mock:
+            response = update_user(user_id, payload={"phone": "4125551234"})
+
+        self.assertEqual(response, persisted)
+        self.assertEqual(update_mock.call_args.kwargs["patch"]["phone"], "4125551234")
+        self.assertEqual(update_mock.call_args.kwargs["patch"]["notifPrefs"], ["email"])
+
     def test_update_user_auto_removes_text_pref_when_phone_cleared(self):
         user_id = ObjectId()
         current = {"_id": user_id, "notifPrefs": ["email", "text"], "phone": "+15550001111"}

--- a/backend/tests/unit/test_validators.py
+++ b/backend/tests/unit/test_validators.py
@@ -3,7 +3,7 @@ import unittest
 from bson import ObjectId
 
 from errors import APIError
-from validators import normalize_email, parse_distinct_object_ids, parse_enum_set
+from validators import is_e164_phone, normalize_email, parse_distinct_object_ids, parse_enum_set
 
 
 class ValidatorTests(unittest.TestCase):
@@ -29,6 +29,18 @@ class ValidatorTests(unittest.TestCase):
     def test_parse_enum_set_rejects_invalid(self):
         with self.assertRaises(APIError):
             parse_enum_set(["email", "push"], field_name="notifPrefs", allowed={"email", "text"})
+
+    def test_is_e164_phone_accepts_plus_and_digits(self):
+        self.assertTrue(is_e164_phone("+15550001111"))
+        self.assertTrue(is_e164_phone("  +441234567890  "))
+
+    def test_is_e164_phone_rejects_naive_or_invalid(self):
+        self.assertFalse(is_e164_phone("4125551234"))
+        self.assertFalse(is_e164_phone("+0123456789"))
+        self.assertFalse(is_e164_phone("+1"))
+        self.assertFalse(is_e164_phone("+1abc"))
+        self.assertFalse(is_e164_phone(""))
+        self.assertFalse(is_e164_phone("+1" + "0" * 15))
 
 
 if __name__ == "__main__":

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -69,8 +69,6 @@ def optional_phone(value: Any) -> str | None:
     phone = value.strip()
     if not phone:
         return None
-    if not phone.startswith("+") or not phone[1:].isdigit():
-        raise APIError(422, "phone must use E.164 format")
     return phone
 
 

--- a/backend/validators.py
+++ b/backend/validators.py
@@ -72,6 +72,19 @@ def optional_phone(value: Any) -> str | None:
     return phone
 
 
+def is_e164_phone(value: str) -> bool:
+    """True if ``value`` is a plausible E.164 destination (e.g. Twilio ``to``)."""
+    s = value.strip()
+    if len(s) < 2 or not s.startswith("+"):
+        return False
+    digits = s[1:]
+    if not digits.isdigit() or digits[0] == "0":
+        return False
+    if not 2 <= len(digits) <= 15:
+        return False
+    return True
+
+
 def parse_distinct_object_ids(values: Any, field_name: str) -> list[ObjectId]:
     if values is None:
         return []

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -80,6 +80,7 @@ function toSessionUser(session: ApiSessionMe): SessionUser {
     emailNotifications: session.emailNotifications,
     smsNotifications: session.smsNotifications,
     hasPhone: session.hasPhone,
+    hasSmsPhone: session.hasSmsPhone,
   };
 }
 

--- a/frontend/src/lib/api/contracts/types.ts
+++ b/frontend/src/lib/api/contracts/types.ts
@@ -53,6 +53,8 @@ export interface ApiSessionMe {
   emailNotifications: boolean;
   smsNotifications: boolean;
   hasPhone: boolean;
+  /** True when stored phone is usable as an SMS destination (E.164). */
+  hasSmsPhone: boolean;
 }
 
 export interface ApiMemberMailboxDay {
@@ -79,6 +81,7 @@ export interface ApiMemberPreferences {
   emailNotifications: boolean;
   smsNotifications: boolean;
   hasPhone: boolean;
+  hasSmsPhone: boolean;
 }
 
 export type ApiMailRequestStatus = "ACTIVE" | "CANCELLED" | "RESOLVED";

--- a/frontend/src/lib/member-preferences.ts
+++ b/frontend/src/lib/member-preferences.ts
@@ -2,6 +2,8 @@ export interface NotificationPreferenceState {
   emailNotifications: boolean;
   smsNotifications: boolean;
   hasPhone: boolean;
+  /** Backend: phone is E.164 and can be used for SMS. */
+  hasSmsPhone: boolean;
 }
 
 export interface NotificationSettingsState extends NotificationPreferenceState {
@@ -11,12 +13,16 @@ export interface NotificationSettingsState extends NotificationPreferenceState {
 }
 
 export function deriveSettingsState(state: NotificationPreferenceState): NotificationSettingsState {
-  const smsDisabled = !state.hasPhone;
+  const smsDisabled = !state.hasSmsPhone;
   return {
     ...state,
-    smsNotifications: state.hasPhone ? state.smsNotifications : false,
+    smsNotifications: state.hasSmsPhone ? state.smsNotifications : false,
     smsDisabled,
-    smsInlineMessage: smsDisabled ? "Add a phone number to enable SMS notifications." : null,
+    smsInlineMessage: smsDisabled
+      ? state.hasPhone
+        ? "Use a phone number in international format (E.164, e.g. +1…) to enable SMS notifications."
+        : "Add a phone number to enable SMS notifications."
+      : null,
   };
 }
 
@@ -31,8 +37,8 @@ export function buildPreferencePatch(
   }
 
   if (typeof updates.smsNotifications === "boolean") {
-    patch.smsNotifications = current.hasPhone ? updates.smsNotifications : false;
-  } else if (!current.hasPhone && current.smsNotifications) {
+    patch.smsNotifications = current.hasSmsPhone ? updates.smsNotifications : false;
+  } else if (!current.hasSmsPhone && current.smsNotifications) {
     patch.smsNotifications = false;
   }
 

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -9,6 +9,7 @@ export interface SessionUser {
   emailNotifications: boolean;
   smsNotifications: boolean;
   hasPhone: boolean;
+  hasSmsPhone: boolean;
 }
 
 export interface FeatureFlags {
@@ -30,6 +31,7 @@ interface AppState {
     emailNotifications: boolean;
     smsNotifications: boolean;
     hasPhone: boolean;
+    hasSmsPhone: boolean;
   }) => void;
   logout: () => void;
 }

--- a/frontend/src/pages/member/NotificationSettings.tsx
+++ b/frontend/src/pages/member/NotificationSettings.tsx
@@ -19,8 +19,14 @@ const NotificationSettings = () => {
       emailNotifications: sessionUser?.emailNotifications ?? false,
       smsNotifications: sessionUser?.smsNotifications ?? false,
       hasPhone: sessionUser?.hasPhone ?? false,
+      hasSmsPhone: sessionUser?.hasSmsPhone ?? false,
     }),
-    [sessionUser?.emailNotifications, sessionUser?.smsNotifications, sessionUser?.hasPhone],
+    [
+      sessionUser?.emailNotifications,
+      sessionUser?.smsNotifications,
+      sessionUser?.hasPhone,
+      sessionUser?.hasSmsPhone,
+    ],
   );
   const activePrefs = optimisticPrefs ?? basePrefs;
   const settings = deriveSettingsState(activePrefs);
@@ -40,6 +46,7 @@ const NotificationSettings = () => {
           emailNotifications: updated.emailNotifications,
           smsNotifications: updated.smsNotifications,
           hasPhone: updated.hasPhone,
+          hasSmsPhone: updated.hasSmsPhone,
         };
         setSessionNotificationPreferences(next);
         setOptimisticPrefs(next);
@@ -61,7 +68,7 @@ const NotificationSettings = () => {
 
   useEffect(() => {
     if (pending) return;
-    if (!activePrefs.hasPhone && activePrefs.smsNotifications) {
+    if (!activePrefs.hasSmsPhone && activePrefs.smsNotifications) {
       const patch = buildPreferencePatch(basePrefs, { smsNotifications: false });
       const optimisticNext = {
         ...basePrefs,
@@ -69,7 +76,7 @@ const NotificationSettings = () => {
       };
       void persistPreferences(patch, optimisticNext, basePrefs);
     }
-  }, [pending, activePrefs.hasPhone, activePrefs.smsNotifications, basePrefs, persistPreferences]);
+  }, [pending, activePrefs.hasSmsPhone, activePrefs.smsNotifications, basePrefs, persistPreferences]);
 
   if (!sessionUser) return null;
 

--- a/frontend/src/test/app-auth.test.tsx
+++ b/frontend/src/test/app-auth.test.tsx
@@ -74,6 +74,7 @@ describe("App magic-link bootstrap", () => {
       emailNotifications: true,
       smsNotifications: false,
       hasPhone: false,
+      hasSmsPhone: false,
     });
 
     render(

--- a/frontend/src/test/member-preferences.test.ts
+++ b/frontend/src/test/member-preferences.test.ts
@@ -9,6 +9,7 @@ describe("member preferences helpers", () => {
         emailNotifications: true,
         smsNotifications: true,
         hasPhone: false,
+        hasSmsPhone: false,
       },
       {},
     );
@@ -22,6 +23,7 @@ describe("member preferences helpers", () => {
         emailNotifications: true,
         smsNotifications: false,
         hasPhone: true,
+        hasSmsPhone: true,
       },
       { smsNotifications: true },
     );
@@ -35,6 +37,7 @@ describe("member preferences helpers", () => {
         emailNotifications: false,
         smsNotifications: false,
         hasPhone: true,
+        hasSmsPhone: true,
       },
       { emailNotifications: true },
     );
@@ -47,10 +50,40 @@ describe("member preferences helpers", () => {
       emailNotifications: true,
       smsNotifications: true,
       hasPhone: false,
+      hasSmsPhone: false,
     });
 
     expect(state.smsDisabled).toBe(true);
     expect(state.smsNotifications).toBe(false);
     expect(state.smsInlineMessage).toBe("Add a phone number to enable SMS notifications.");
+  });
+
+  it("deriveSettingsState_disables_sms_when_phone_is_not_e164", () => {
+    const state = deriveSettingsState({
+      emailNotifications: true,
+      smsNotifications: true,
+      hasPhone: true,
+      hasSmsPhone: false,
+    });
+
+    expect(state.smsDisabled).toBe(true);
+    expect(state.smsNotifications).toBe(false);
+    expect(state.smsInlineMessage).toBe(
+      "Use a phone number in international format (E.164, e.g. +1…) to enable SMS notifications.",
+    );
+  });
+
+  it("buildPreferencePatch_clears_sms_when_phone_present_but_not_e164", () => {
+    const patch = buildPreferencePatch(
+      {
+        emailNotifications: true,
+        smsNotifications: true,
+        hasPhone: true,
+        hasSmsPhone: false,
+      },
+      {},
+    );
+
+    expect(patch).toEqual({ smsNotifications: false });
   });
 });


### PR DESCRIPTION
**Summary**
- Removes strict E.164 check from optional_phone() in backend/validators.py.
- Prevents unnecessary 422 responses for optional phone input.
- Preserves existing normalization behavior (trim + empty => None).

**Test plan**
- [ ] Submit request with phone omitted → succeeds
- [ ] Submit request with phone: "" / whitespace → treated as None, succeeds
- [ ] Submit request with non-E.164 phone (e.g. "4125551234") → no 422 from validator
- [ ] Submit request with E.164 phone (e.g. "+14125551234") → still succeeds

Closes #120 