### PR TITLE
Route review-page <img> through API base path

### DIFF
--- a/frontend/src/pages/admin/OcrQueue.tsx
+++ b/frontend/src/pages/admin/OcrQueue.tsx
@@ -26,6 +26,7 @@ import {
   type ApiOcrJob,
   type ApiOcrQueueItem,
 } from "@/lib/api";
+import { buildUrl } from "@/lib/http/client";
 import { useAppStore } from "@/lib/store";
 import { findCloseMailboxMatch } from "@/lib/mailboxMatch";
 
@@ -557,9 +558,9 @@ const OcrQueue = () => {
               {/* Left Column: Image */}
               <div className="rounded-xl overflow-hidden bg-muted flex items-center justify-center border aspect-[3/4] md:aspect-auto">
                 {effectiveItem && (effectiveItem.imagePath || effectiveItem.fileId) ? (
-                   <img 
-                     src={`/api/ocr/queue/${effectiveItem.id}/image`} 
-                     alt="Mail Item" 
+                   <img
+                     src={buildUrl(`/ocr/queue/${effectiveItem.id}/image`)}
+                     alt="Mail Item"
                      className="max-h-full max-w-full object-contain"
                    />
                 ) : (


### PR DESCRIPTION
## Summary
The OCR review page hardcoded `<img src="/api/ocr/queue/.../image">`. In production the site is served at `hub.avenuworkspaces.com/mail/...` and `nginx-rp` only forwards `/mail/*` to the avenu-mail stack, so the hardcoded `/api/...` request went to whatever app owns the root and returned its 404 page (Next.js in our case), never reaching the Flask backend.

Switch to `buildUrl()` so the path picks up `VITE_API_BASE_URL` (`/mail/api` in both dev and prod), matching every other API call in the codebase.

This bug pre-dates the volume-backed image staging work; the staging volume itself is fine and is also needed for the fix to actually surface anything.

## Test plan
- [ ] CI green.
- [ ] After merge + redeploy: upload a fresh OCR job in `/mail/admin/recording`, confirm the image renders, DevTools shows `GET /mail/api/ocr/queue/<id>/image` returning 200.